### PR TITLE
[Fix] Add support for Svelte and Vue extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "intellisense"
   ],
   "description": "Intellisense support for CSS Variables",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "phoenisx",
   "license": "MIT",
   "homepage": "https://github.com/willofindie/vscode-cssvar",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "onLanguage:sass",
     "onLanguage:less",
     "onLanguage:postcss",
+    "onLanguage:svelte",
+    "onLanguage:vue",
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
     "onLanguage:typescript",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,15 @@ export const JS_IDS = [
   "javascript",
   "javascriptreact",
 ] as const;
-export const CSS_IDS = ["css", "scss", "sass", "less", "postcss"] as const;
+export const CSS_IDS = [
+  "css",
+  "scss",
+  "sass",
+  "less",
+  "postcss",
+  "vue",
+  "svelte",
+] as const;
 export const SUPPORTED_LANGUAGE_IDS = [...CSS_IDS, ...JS_IDS] as const;
 export type SupportedLanguageIds = typeof SUPPORTED_LANGUAGE_IDS[number];
 
@@ -16,6 +24,8 @@ export type SupportedExtensionNames =
   | "sass"
   | "less"
   | "postcss"
+  | "vue"
+  | "svelte"
   | "ts"
   | "tsx"
   | "jsx"

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -58,6 +58,8 @@ describe("Utility Function Tests", () => {
       const input1 = "for(let i=4; i>0; --i) {}";
       const input2 = "let x = --i";
       const input3 = "--i";
+      // Need to fix intellisense getting triggered for input4 for JS like files.
+      const input4 = '{x: "(--i) reduces i by 1"';
       const result1 = restrictIntellisense(
         input1,
         "javascript",


### PR DESCRIPTION
As of now, the support is gained only when these extensions are considered as a CSS file. Will look into the details later.

Fixes: #17 