### PR TITLE
[Fix] Add support for recursively parse colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "intellisense"
   ],
   "description": "Intellisense support for CSS Variables",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "phoenisx",
   "license": "MIT",
   "homepage": "https://github.com/willofindie/vscode-cssvar",

--- a/src/color-parser.ts
+++ b/src/color-parser.ts
@@ -57,12 +57,23 @@ export const parseToRgb = (color: string) => {
   return null;
 };
 
-export const serializeColor = (color: string) => {
+export const serializeColor = (
+  color: string
+): {
+  isColor: boolean;
+  color: string;
+} => {
   const parsedColor = parseColor(color);
 
   if (parsedColor) {
-    return serializeRgb(CONVERTERS[parsedColor.mode](parsedColor as any));
+    return {
+      isColor: true,
+      color: serializeRgb(CONVERTERS[parsedColor.mode](parsedColor as any)),
+    };
   }
 
-  return "";
+  return {
+    isColor: false,
+    color,
+  };
 };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -290,7 +290,7 @@ export const parseFiles = async function (
 
   if (CACHE.cssVars !== cssVars) {
     try {
-      const [vars, cssVarsMap] = populateValue(cssVars);
+      const [vars, cssVarsMap] = await populateValue(cssVars);
       CACHE.cssVarDefinitionsMap = vars.reduce((defs, cssVar) => {
         if (!cssVar.location) {
           return defs;

--- a/src/test/color-parser.test.ts
+++ b/src/test/color-parser.test.ts
@@ -2,87 +2,90 @@ import { serializeColor } from "../color-parser";
 
 describe("Happy Flows color-parser", () => {
   it("can parse transparent", () => {
-    const color = serializeColor("transparent");
-    expect(color).toBe("rgba(0, 0, 0, 0)");
+    const result = serializeColor("transparent");
+    expect(result.color).toBe("rgba(0, 0, 0, 0)");
   });
 
   it("can parse named", () => {
-    const color = serializeColor("tomato");
-    expect(color).toBe("rgb(255, 99, 71)");
+    const result = serializeColor("tomato");
+    expect(result.color).toBe("rgb(255, 99, 71)");
   });
 
   it("can parse hex3, hex4, hex6, hex8", () => {
-    const color3 = serializeColor("#333");
-    expect(color3).toBe("rgb(51, 51, 51)");
-    const color6 = serializeColor("#333333");
-    expect(color6).toBe("rgb(51, 51, 51)");
-    const color4 = serializeColor("#3333");
-    expect(color4).toBe("rgba(51, 51, 51, 0.2)");
-    const color8 = serializeColor("#33333333");
-    expect(color8).toBe("rgba(51, 51, 51, 0.2)");
+    const result3 = serializeColor("#333");
+    expect(result3.color).toBe("rgb(51, 51, 51)");
+    const result6 = serializeColor("#333333");
+    expect(result6.color).toBe("rgb(51, 51, 51)");
+    const result4 = serializeColor("#3333");
+    expect(result4.color).toBe("rgba(51, 51, 51, 0.2)");
+    const result8 = serializeColor("#33333333");
+    expect(result8.color).toBe("rgba(51, 51, 51, 0.2)");
   });
 
   it("can parse rgb", () => {
     const rgbResult = "rgb(25, 60, 30)";
     const rgbaResult = "rgba(25, 60, 30, 0.5)";
-    let color = serializeColor(rgbResult);
-    expect(color).toBe(rgbResult);
-    color = serializeColor(rgbaResult);
-    expect(color).toBe(rgbaResult);
+    let result = serializeColor(rgbResult);
+    expect(result.color).toBe(rgbResult);
+    result = serializeColor(rgbaResult);
+    expect(result.color).toBe(rgbaResult);
   });
 
   it("can parse hsl", () => {
     const hslCSS_L3 = "hsl(235, 100%, 50%)";
     const hslCSS_L4 = "hsl(235 100% 50%)";
     const hsla = "hsla(235 100% 50% / .5)";
-    const colorL3 = serializeColor(hslCSS_L3);
-    const colorL4 = serializeColor(hslCSS_L4);
-    const color = serializeColor(hsla);
-    expect(colorL3).toBe("rgb(0, 21, 255)");
-    expect(colorL4).toBe("rgb(0, 21, 255)");
-    expect(color).toBe("rgba(0, 21, 255, 0.5)");
+    const resultL3 = serializeColor(hslCSS_L3);
+    const resultL4 = serializeColor(hslCSS_L4);
+    const result = serializeColor(hsla);
+    expect(resultL3.color).toBe("rgb(0, 21, 255)");
+    expect(resultL4.color).toBe("rgb(0, 21, 255)");
+    expect(result.color).toBe("rgba(0, 21, 255, 0.5)");
   });
 
   it("can parse hwb", () => {
-    const color = serializeColor("hwb(194 0% 0%)");
-    const colorAlpha = serializeColor("hwb(194 0% 0% / .5)");
-    expect(color).toBe("rgb(0, 195, 255)");
-    expect(colorAlpha).toBe("rgba(0, 195, 255, 0.5)");
+    const result = serializeColor("hwb(194 0% 0%)");
+    const resultAlpha = serializeColor("hwb(194 0% 0% / .5)");
+    expect(result.color).toBe("rgb(0, 195, 255)");
+    expect(resultAlpha.color).toBe("rgba(0, 195, 255, 0.5)");
   });
 
   it("can parse lch", () => {
-    const color = serializeColor("lch(52.2345% 72.2 56.2)");
-    const colorAlpha = serializeColor("lch(52.2345% 72.2 56.2 / .5)");
-    expect(color).toBe("rgb(198, 93, 6)");
-    expect(colorAlpha).toBe("rgba(198, 93, 6, 0.5)");
+    const result = serializeColor("lch(52.2345% 72.2 56.2)");
+    const resultAlpha = serializeColor("lch(52.2345% 72.2 56.2 / .5)");
+    expect(result.color).toBe("rgb(198, 93, 6)");
+    expect(resultAlpha.color).toBe("rgba(198, 93, 6, 0.5)");
   });
 
   it("can parse lab", () => {
-    const color = serializeColor("lab(52.2345% 40.1645 59.9971)");
-    const colorAlpha = serializeColor("lab(52.2345% 40.1645 59.9971 / .5)");
-    expect(color).toBe("rgb(198, 93, 6)");
-    expect(colorAlpha).toBe("rgba(198, 93, 6, 0.5)");
+    const result = serializeColor("lab(52.2345% 40.1645 59.9971)");
+    const resultAlpha = serializeColor("lab(52.2345% 40.1645 59.9971 / .5)");
+    expect(result.color).toBe("rgb(198, 93, 6)");
+    expect(resultAlpha.color).toBe("rgba(198, 93, 6, 0.5)");
   });
 });
 
 describe("Failures color-parser", () => {
   it("empty string", () => {
-    const color = serializeColor("");
-    expect(color).toBe("");
+    const result = serializeColor("");
+    expect(result.color).toBe("");
   });
 
   it("wrong hex", () => {
-    const color = serializeColor("#34345");
-    expect(color).toBe("");
+    const result = serializeColor("#34345");
+    expect(result.isColor).toBeFalsy();
+    expect(result.color).toBe("#34345");
   });
 
   it("unknown named CSS color", () => {
-    const color = serializeColor("flamingo");
-    expect(color).toBe("");
+    const result = serializeColor("flamingo");
+    expect(result.isColor).toBeFalsy();
+    expect(result.color).toBe("flamingo");
   });
 
   it("Unsupported CSS4 custom <color>: color() API", () => {
-    const color = serializeColor("color(display-p3 1 0.5 0)");
-    expect(color).toBe("");
+    const result = serializeColor("color(display-p3 1 0.5 0)");
+    expect(result.isColor).toBeFalsy();
+    expect(result.color).toBe("color(display-p3 1 0.5 0)");
   });
 })


### PR DESCRIPTION
This fixes #25 

The following example now generates a proper parsed color for a CSS color function.

```css
:root {
  --gray-3-hsl: 210 14% 89%;
}

body {
  --gray-3-hsl-solid: hsl(var(--gray-3-hsl));
  --gray-3-hsl-translucent: hsl(var(--gray-3-hsl) / 30%);
}

.element {
  color: var(--gray-3-hsl-solid);
  background-color: var(--gray-3-hsl-translucent);
}
```

Do keep in mind that directly accessing a non color variable won't work. The following won't work:

```css
:root {
  --gray-3-hsl: 210 14% 89%;
}

.element {
  /* This won't parse the colors, as the variable points to a non-color value */
  color: hsl(var(--gray-3-hsl));
  background-color: hsl(var(--gray-3-hsl) / 30%);
}
```