### PR TITLE
[#32][Fix] Support for Multi Root workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules
 *.vsix
 yarn-error.log
 .DS_Store
+coverage/
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,10 +13,15 @@
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--disable-extension=phoenisx.cssvar"
       ],
-      "skipFiles": ["**/node_modules/**"],
-      "outFiles": [
-        "${workspaceFolder}/out/**/*.js"
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
       ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js",
+        "!**/node_modules/**"
+      ],
+      "skipFiles": ["**/node_modules/**"],
       "preLaunchTask": "npm: watch"
     },
     {

--- a/__mocks__/vscode.js
+++ b/__mocks__/vscode.js
@@ -92,6 +92,10 @@ const languages = {
 const window = {
   // eslint-disable-next-line no-console
   showErrorMessage: jest.fn(msg => console.trace(msg)),
+  // For now I am not testing switching between muti-roots
+  onDidChangeActiveTextEditor: cb => {
+    cb && cb();
+  },
 };
 
 const Uri = {

--- a/examples/basics/.vscode/settings.json
+++ b/examples/basics/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "cssvar.files": ["global.css", "local.css"],
-  "cssvar.extensions": ["css", "postcss"]
-}

--- a/examples/basics/README.md
+++ b/examples/basics/README.md
@@ -1,0 +1,11 @@
+# Brief
+
+This extension works flawlessly with pure CSS projects.
+No settings required for pure CSS projects, but you can customize the settings if needed.
+
+**NOTE ::**
+By default, when not settings is provided, this extension will scan all CSS files in current project.
+This is fine for smaller projects, but is not recommended for larger projects, since scanning and parsing
+a huge list of css files can make the extension slow and might not be desirable.
+
+Thus, it is recommended to at-least set `cssvar.files` settings for your projects.

--- a/examples/css-extensions/.vscode/settings.json
+++ b/examples/css-extensions/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "cssvar.files": ["**/*.css", "**/*.scss"],
+  "cssvar.postcssSyntax": ["postcss-scss"]
+}

--- a/examples/css-extensions/README.md
+++ b/examples/css-extensions/README.md
@@ -1,0 +1,14 @@
+# Brief
+
+In case you are not directly working CSS files and using CSS extensions like SASS, SCSS, LESS, POSTCSS
+you can still use this extension.
+
+CSS extensions can have some specific syntax that are not compatible with pure CSS specs, like
+SASS interpolations, single line comments and more.
+
+This extension will work fine without any customization unless you are using non-standard CSS syntax.
+
+To support non-standard CSS syntax, this extension uses `cssvar.postcssSyntax`.
+This example demonstrates the use of that setting.
+
+Details can be read [here for Customization](../../customize-extension.md).

--- a/examples/css-extensions/index.css
+++ b/examples/css-extensions/index.css
@@ -1,0 +1,3 @@
+.container {
+  padding: var(--space-1) var(--space-2);
+}

--- a/examples/css-extensions/package.json
+++ b/examples/css-extensions/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "css-extensions",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "postcss": "8",
+    "postcss-scss": "^4.0.4"
+  }
+}

--- a/examples/css-extensions/pnpm-lock.yaml
+++ b/examples/css-extensions/pnpm-lock.yaml
@@ -1,0 +1,44 @@
+lockfileVersion: 5.4
+
+specifiers:
+  postcss: '8'
+  postcss-scss: ^4.0.4
+
+dependencies:
+  postcss: 8.4.14
+  postcss-scss: 4.0.4_postcss@8.4.14
+
+packages:
+
+  /nanoid/3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: false
+
+  /picocolors/1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: false
+
+  /postcss-scss/4.0.4_postcss@8.4.14:
+    resolution: {integrity: sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      postcss: 8.4.14
+    dev: false
+
+  /postcss/8.4.14:
+    resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: false
+
+  /source-map-js/1.0.2:
+    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+    engines: {node: '>=0.10.0'}
+    dev: false

--- a/examples/css-extensions/styles.scss
+++ b/examples/css-extensions/styles.scss
@@ -1,0 +1,12 @@
+:root {
+  --space-1: 1rem;
+  --space-2: 2rem;
+}
+
+.app {
+  // Nested rules are not supported in CSS
+  .child {
+    color: var(--brand-1);
+    background-color: var(--brand-3);
+  }
+}

--- a/examples/css-extensions/theme.scss
+++ b/examples/css-extensions/theme.scss
@@ -1,0 +1,12 @@
+// Single line comments is not supported in CSS.
+$color-1: #FF8A65;
+$color-2: #8D6E63;
+$color-3: #BDBDBD;
+
+:root {
+  --brand-1: #{$color-1};
+  --brand-2: #{$color-2};
+  --brand-3: #{$color-3};
+}
+
+

--- a/examples/multi-root/README.md
+++ b/examples/multi-root/README.md
@@ -1,0 +1,11 @@
+# Brief
+
+Multi Root support for CSS variables is pretty new, released with `v1.5`.
+Support for CSS variables is pretty similar to single folder support in VSCode.
+
+Some differences from single folder approach are mentioned below:
+
+- Some of the extension settings can be either set for the entire project or specific to each root folder
+- Switching between CSS files from different Root folders requires file updates for the extension to
+  trigger again.
+  - Not sure why this happens, but will try to figure out a fix (if present) in upcoming releases.

--- a/examples/multi-root/multi-root.code-workspace
+++ b/examples/multi-root/multi-root.code-workspace
@@ -1,0 +1,22 @@
+{
+	"folders": [
+		{ "path": "./proj-1" },
+		{ "path": "./proj-2" },
+		{ "path": "./proj-3" },
+		{ "path": "." },
+	],
+	"settings": {
+		"files.exclude": {
+			"**/.git": true,
+			"**/.svn": true,
+			"**/.hg": true,
+			"**/CVS": true,
+			"**/.DS_Store": true,
+			"**/Thumbs.db": true,
+			"proj-1": true,
+			"proj-2": true,
+			"proj-3": true,
+		},
+		"cssvar.enableGotoDef": false
+	}
+}

--- a/examples/multi-root/multi-root.code-workspace
+++ b/examples/multi-root/multi-root.code-workspace
@@ -17,6 +17,6 @@
 			"proj-2": true,
 			"proj-3": true,
 		},
-		"cssvar.enableGotoDef": false
+		"cssvar.enableGotoDef": true
 	}
 }

--- a/examples/multi-root/package.json
+++ b/examples/multi-root/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "multi-root",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bootstrap": "^5.2.0",
+    "postcss": "^8.4.14",
+    "postcss-scss": "^4.0.4"
+  }
+}

--- a/examples/multi-root/pnpm-lock.yaml
+++ b/examples/multi-root/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: 5.4
+
+specifiers:
+  bootstrap: ^5.2.0
+  postcss: ^8.4.14
+  postcss-scss: ^4.0.4
+
+dependencies:
+  bootstrap: 5.2.0
+  postcss: 8.4.14
+  postcss-scss: 4.0.4_postcss@8.4.14
+
+packages:
+
+  /bootstrap/5.2.0:
+    resolution: {integrity: sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==}
+    peerDependencies:
+      '@popperjs/core': ^2.11.5
+    dev: false
+
+  /nanoid/3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: false
+
+  /picocolors/1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: false
+
+  /postcss-scss/4.0.4_postcss@8.4.14:
+    resolution: {integrity: sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      postcss: 8.4.14
+    dev: false
+
+  /postcss/8.4.14:
+    resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: false
+
+  /source-map-js/1.0.2:
+    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+    engines: {node: '>=0.10.0'}
+    dev: false

--- a/examples/multi-root/proj-1/index.css
+++ b/examples/multi-root/proj-1/index.css
@@ -1,0 +1,9 @@
+:root {
+  --color-1: #4CAF50;
+  --color-2: #01579B;
+}
+
+.app {
+  color: var(--color-1);
+  background-color: var(--color-1);
+}

--- a/examples/multi-root/proj-2/.vscode/settings.json
+++ b/examples/multi-root/proj-2/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "cssvar.files": ["**/*.scss"],
+  "cssvar.postcssSyntax": ["postcss-scss"]
+}

--- a/examples/multi-root/proj-2/index.scss
+++ b/examples/multi-root/proj-2/index.scss
@@ -1,0 +1,7 @@
+.app {
+  // Nested rules are not supported in CSS
+  .child {
+    color: var(--brand-1);
+    background-color: var(--brand-3);
+  }
+}

--- a/examples/multi-root/proj-2/theme.scss
+++ b/examples/multi-root/proj-2/theme.scss
@@ -1,0 +1,10 @@
+// Single line comments is not supported in CSS.
+$color-1: #FF8A65;
+$color-2: #8D6E63;
+$color-3: #BDBDBD;
+
+:root {
+  --brand-1: #{$color-1};
+  --brand-2: #{$color-2};
+  --brand-3: #{$color-3};
+}

--- a/examples/multi-root/proj-3/.vscode/settings.json
+++ b/examples/multi-root/proj-3/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cssvar.files": ["../node_modules/bootstrap/dist/css/bootstrap.css"],
+}

--- a/examples/multi-root/proj-3/app.css
+++ b/examples/multi-root/proj-3/app.css
@@ -1,0 +1,5 @@
+.app {
+  color: var(--bs-accordion-active-bg);
+  border-radius: var(--bs-border-radius);
+  border-color: var(--bs-border-color);
+}

--- a/examples/multi-root/proj-3/index.css
+++ b/examples/multi-root/proj-3/index.css
@@ -1,0 +1,4 @@
+body {
+  color: var(--bs-accordion-active-bg);
+  background-color: var(--bs-accordion-active-color);
+}

--- a/package.json
+++ b/package.json
@@ -49,68 +49,125 @@
   "preview": false,
   "contributes": {
     "configuration": {
-      "title": "CSS Var Complete",
+      "title": "CSS Variables",
       "properties": {
         "cssvar.files": {
-          "type": [
-            "array",
-            "object",
-            "null"
-          ],
-          "default": null,
-          "description": "CSS variable file relative/absolute paths to include for the Intellisense"
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Relative/Absolute paths to CSS variable file sources",
+          "scope": "resource",
+          "examples": [
+            [
+              "src/**/*.css",
+              "styles/global.css"
+            ]
+          ]
         },
         "cssvar.extensions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "default": null,
-          "description": "File extensions to include"
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "File extensions for which IntelliSense will be enabled",
+          "scope": "resource",
+          "examples": [
+            [
+              "css",
+              "scss",
+              "tsx",
+              "jsx"
+            ]
+          ]
         },
         "cssvar.themes": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "default": null,
-          "description": "CSS Theme classname list"
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "CSS Theme classnames used in source files",
+          "scope": "resource",
+          "examples": [
+            [
+              "dark",
+              "dim"
+            ]
+          ]
         },
         "cssvar.excludeThemedVariables": {
           "type": "boolean",
           "default": false,
-          "description": "Exclude themed variables"
+          "markdownDescription": "Exclude themed variables to remove unnecessary duplicates",
+          "scope": "resource",
+          "examples": [
+            true,
+            false
+          ]
         },
         "cssvar.disableSort": {
           "type": "boolean",
           "default": false,
-          "description": "Disables default sorting applied by VSCode"
+          "markdownDescription": "Disables default sorting applied by VSCode",
+          "scope": "window",
+          "examples": [
+            true,
+            false
+          ]
         },
         "cssvar.enableColors": {
           "type": "boolean",
           "default": true,
-          "description": "Enable VScode's Color Representation feature when true"
+          "markdownDescription": "Enable VScode's Color Representation feature when true",
+          "scope": "window",
+          "examples": [
+            true,
+            false
+          ]
         },
         "cssvar.enableGotoDef": {
           "type": "boolean",
           "default": true,
-          "description": "Enable VScode's Goto Definition feature for CSS Variables"
+          "markdownDescription": "Enable VScode's Goto Definition feature for CSS Variables",
+          "scope": "window",
+          "examples": [
+            true,
+            false
+          ]
         },
         "cssvar.postcssPlugins": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "default": null,
-          "description": "Provide PostCSS Plugins to support custom CSS features"
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Provide PostCSS Plugins to support custom CSS features. List of PostCSS plugin names can be found in [PostCSS Doc](https://github.com/postcss/postcss#plugins)",
+          "scope": "resource",
+          "examples": [
+            [
+              "postcss-nested",
+              "webp-in-css"
+            ]
+          ]
         },
         "cssvar.postcssSyntax": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "default": null,
-          "description": "Add support for custom CSS compilers like SCSS, SASS, LESS and more"
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Add support for custom CSS compilers like SCSS, SASS, LESS and more. Currently supports: 'postcss-scss', 'postcss-sass', 'postcss-less'. List of all PostCSS syntax names can be found in [PostCSS Doc](https://github.com/postcss/postcss#syntaxes)",
+          "scope": "resource",
+          "examples": [
+            [
+              "postcss-scss",
+              "postcss-sass",
+              "postcss-less"
+            ]
+          ]
         }
       }
     }
@@ -143,7 +200,7 @@
     "@typescript-eslint/parser": "^5.17.0",
     "babel-jest": "^26.6.3",
     "cross-env": "^7.0.3",
-    "esbuild": "^0.14.28",
+    "esbuild": "^0.14.49",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-jest": "^24.7.0",
@@ -156,7 +213,7 @@
     "prettier": "^2.6.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.70.1",
-    "rollup-plugin-esbuild": "^4.8.2",
+    "rollup-plugin-esbuild": "^4.9.1",
     "typescript": "^4.6.3"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,11 @@ import esbuild from "rollup-plugin-esbuild";
 import pkg from "./package.json";
 import tsConfig from "./tsconfig.json";
 
+const isProd = process.env.NODE_ENV === "production";
+
+/**
+ * @type {import("rollup").RollupOptions[]}
+ */
 export default [
   {
     input: "src/extension.ts",
@@ -15,7 +20,10 @@ export default [
     },
     plugins: [
       replace({
-        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || "development"),
+        "process.env.NODE_ENV": JSON.stringify(
+          process.env.NODE_ENV || "development"
+        ),
+        preventAssignment: true,
       }),
       resolve({
         browser: false,
@@ -25,8 +33,8 @@ export default [
         ignoreGlobal: true,
       }),
       esbuild({
-        minify: process.env.NODE_ENV === "production",
-        sourceMap: process.env.NODE_ENV !== "production",
+        minify: isProd,
+        sourceMap: !isProd,
         target: tsConfig.compilerOptions.target,
         define: {
           __VERSION__: JSON.stringify(pkg.version),

--- a/src/Notes.md
+++ b/src/Notes.md
@@ -1,0 +1,40 @@
+# [Brainstorming] Multi Root Workspace folders:
+
+- VSCode doesn't provide any API to get configuration for active text document.
+  - I mean, we need to manually map CSSVars to a variable that resolves to active folder and it's contents
+
+
+Two ways a user can open VSCode:
+- Without any workspace
+- With multi-root Workspace
+
+## Without any Workspace
+
+As per this [doc](https://github.com/microsoft/vscode/wiki/Adopting-Multi-Root-Workspace-APIs#eliminating-rootpath)
+`workspaceFolders` can be `undefined`. This is how our current code is written.
+
+This is working fine and we do not have to worry about any config mapping to active root folder
+in workspace
+
+## With workspace:
+
+We first need to change all our configuration variables that depend on currently Active folder
+to generate CSS Variables, like `cssvar.files` to support resource scoped configs, i.e.
+`cssvar.resource.files`.
+
+To make the extension work with multi-roots, we need to trigger a function everytime on
+`workspace.onDidOpenTextDocument` and change our Active Folder, which in turn should change
+the active set of CSS Variables for that folder.
+
+If the CSS Variables are not generated, generate them for this folder and set them to activeCSSVariables
+, else we can re-use the cache.
+
+I guess this will solve the issue.
+
+# [Brainstorming] Parse variables from any JS/CSS file
+
+First of all, I want to keep this feature experimental, because all the parsers used in this project
+are battle tested.
+
+If I create a new parser, something very similar to `postcss-safe-parser`, which can parse JS/CSS like
+files properly, it would surely have some trade-offs which I am not aware of right now.

--- a/src/color-provider.ts
+++ b/src/color-provider.ts
@@ -10,6 +10,7 @@ import {
 } from "vscode";
 import { parseToRgb } from "./color-parser";
 import { CACHE } from "./constants";
+import { getActiveRootPath } from "./utils";
 
 const getChunkRange = (startLineNumber: number, endLineNumber: number): Range =>
   new Range(new Position(startLineNumber, 0), new Position(endLineNumber, 0));
@@ -29,6 +30,8 @@ export class CssColorProvider implements DocumentColorProvider {
     let text = document.getText(
       getChunkRange(lineOffset, lineOffset + linesRead)
     );
+    CACHE.activeRootPath = getActiveRootPath();
+
     while (text) {
       const lines = text.split(eol);
       lines.pop(); // Last line will be handled in next loop
@@ -38,7 +41,7 @@ export class CssColorProvider implements DocumentColorProvider {
         for (const cssVarMatch of matches) {
           const match = cssVarMatch[0];
           const key = cssVarMatch[1].trim();
-          const hexColor = CACHE.cssVarsMap[key]?.color;
+          const hexColor = CACHE.cssVarsMap[CACHE.activeRootPath][key]?.color;
           if (hexColor && cssVarMatch.index) {
             const color = parseToRgb(hexColor);
             if (color) {

--- a/src/completion-provider.ts
+++ b/src/completion-provider.ts
@@ -8,7 +8,7 @@ import {
 import { CACHE, SupportedLanguageIds } from "./constants";
 
 import { createCompletionItems } from "./main";
-import { restrictIntellisense } from "./utils";
+import { getActiveRootPath, restrictIntellisense } from "./utils";
 
 export class CssCompletionProvider implements CompletionItemProvider {
   async provideCompletionItems(
@@ -18,6 +18,8 @@ export class CssCompletionProvider implements CompletionItemProvider {
     const firstInLine = new Position(position.line, 0);
     const language: SupportedLanguageIds =
       document.languageId as SupportedLanguageIds;
+
+    CACHE.activeRootPath = getActiveRootPath();
 
     /**
      * VSCode auto-fills extra characters post our current cursor position sometimes
@@ -46,10 +48,15 @@ export class CssCompletionProvider implements CompletionItemProvider {
     }
 
     const region = regions[regions.length - 1];
-    const completionItems = createCompletionItems(CACHE.config, CACHE.cssVars, {
-      region,
-      languageId: language,
-    });
+
+    const completionItems = createCompletionItems(
+      CACHE.config[CACHE.activeRootPath],
+      CACHE.cssVars[CACHE.activeRootPath],
+      {
+        region,
+        languageId: language,
+      }
+    );
     return new CompletionList(completionItems);
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,25 +89,34 @@ export const VAR_KEYWORD_REVERSE = ["(", "r", "a", "v"];
 
 export type CSSVarRecord = { [path: string]: CSSVarDeclarations[] };
 export type CacheType = {
-  cssVars: CSSVarRecord;
-  cssVarsMap: { [varName: string]: CSSVarDeclarations };
-  cssVarDefinitionsMap: { [varName: string]: Location[] };
-  filesToWatch: Set<string>;
+  cssVars: { [activeRootpath: string]: CSSVarRecord };
+  // Reverse map for easy access to CSS variable details
+  cssVarsMap: {
+    [activeRootpath: string]: { [varName: string]: CSSVarDeclarations };
+  };
+  // Keeps a map of each variable's file location
+  cssVarDefinitionsMap: {
+    [activeRootpath: string]: { [varName: string]: Location[] };
+  };
+  filesToWatch: { [activeRootpath: string]: Set<string> };
   fileMetas: {
     [path: string]: {
       path: string;
       lastModified: number;
     };
   };
-  config: Config;
+  config: { [activeRootpath: string]: Config };
+  activeRootPath: string;
 };
+
 export const CACHE: CacheType = {
   cssVars: {},
   cssVarsMap: {},
   cssVarDefinitionsMap: {},
-  filesToWatch: new Set(),
+  filesToWatch: {},
   fileMetas: {},
-  config: {} as Config,
+  config: {}, // Points to active config.
+  activeRootPath: "",
 };
 
 export const POSTCSS_SYNTAX_MODULES: Record<CssExtensions, string> = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,7 +55,7 @@ export interface Config {
 }
 
 export const DEFAULT_CONFIG: Config = {
-  files: ["index.css"],
+  files: ["**/*.css"],
   extensions: [...CSS_IDS],
   themes: [],
   postcssPlugins: [],

--- a/src/definition-provider.ts
+++ b/src/definition-provider.ts
@@ -7,6 +7,7 @@ import {
   TextDocument,
 } from "vscode";
 import { CACHE } from "./constants";
+import { getActiveRootPath } from "./utils";
 
 export class CssDefinitionProvider implements DefinitionProvider {
   async provideDefinition(
@@ -33,7 +34,9 @@ export class CssDefinitionProvider implements DefinitionProvider {
       }
     }
 
-    const locations = CACHE.cssVarDefinitionsMap[exactMatch];
+    CACHE.activeRootPath = getActiveRootPath();
+    const locations =
+      CACHE.cssVarDefinitionsMap[CACHE.activeRootPath][exactMatch];
 
     return locations;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import {
   workspace,
   FileSystemWatcher,
   RelativePattern,
+  TextEditor,
 } from "vscode";
 import { CssColorProvider } from "./color-provider";
 import { CssCompletionProvider } from "./completion-provider";
@@ -23,7 +24,7 @@ const watchers: FileSystemWatcher[] = [];
 export async function activate(context: ExtensionContext): Promise<void> {
   try {
     const { config } = await setup();
-    const [, errorPaths] = await parseFiles(config); // Cache Parsed CSS Vars
+    const [, errorPaths] = await parseFiles(config, { parseAll: true }); // Cache Parsed CSS Vars for all Root folders
     if (errorPaths.length > 0) {
       const relativePaths = errorPaths;
       window.showWarningMessage(
@@ -33,7 +34,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     }
 
     const completionDisposable = languages.registerCompletionItemProvider(
-      config.extensions || DEFAULT_CONFIG.extensions,
+      config[CACHE.activeRootPath].extensions || DEFAULT_CONFIG.extensions,
       new CssCompletionProvider(),
       "-",
       "v",
@@ -43,48 +44,61 @@ export async function activate(context: ExtensionContext): Promise<void> {
     );
     context.subscriptions.push(completionDisposable);
 
-    if (config.enableColors) {
+    if (config[CACHE.activeRootPath].enableColors) {
       const colorDisposable = languages.registerColorProvider(
-        config.extensions || DEFAULT_CONFIG.extensions,
+        config[CACHE.activeRootPath].extensions || DEFAULT_CONFIG.extensions,
         new CssColorProvider()
       );
       context.subscriptions.push(colorDisposable);
     }
 
-    if (config.enableGotoDef) {
+    if (config[CACHE.activeRootPath].enableGotoDef) {
       const definitionDisposable = languages.registerDefinitionProvider(
-        config.extensions || DEFAULT_CONFIG.extensions,
+        config[CACHE.activeRootPath].extensions || DEFAULT_CONFIG.extensions,
         new CssDefinitionProvider()
       );
       context.subscriptions.push(definitionDisposable);
     }
 
+    //#region File Watcher
+    /**
+     * Following code will help in watching file changes, without any 3rd-party libs
+     * This helps to re-calculate CSS Variables, if there is any change.
+     */
     const watchers: FileSystemWatcher[] = [];
-    for (const path of CACHE.filesToWatch) {
-      const relativePattern = new RelativePattern(path, "*");
-      const watcher = workspace.createFileSystemWatcher(relativePattern);
-      watcher.onDidChange(async () => {
-        const [, errorPaths] = await parseFiles(CACHE.config); // Cache Parsed CSS Vars
-        if (errorPaths.length > 0) {
-          const relativePaths = errorPaths;
-          window.showWarningMessage(
-            "Failed to parse CSS variables in files:",
-            `\n\n${relativePaths.join("\n\n")}`
-          );
-        }
-      });
+    const folders = workspace.workspaceFolders || [];
+    for (const folder of folders) {
+      for (const path of CACHE.filesToWatch[folder.uri.fsPath]) {
+        const relativePattern = new RelativePattern(path, "*");
+        const watcher = workspace.createFileSystemWatcher(relativePattern);
+        watcher.onDidChange(async () => {
+          const [, errorPaths] = await parseFiles(CACHE.config); // Cache Parsed CSS Vars
+          if (errorPaths.length > 0) {
+            const relativePaths = errorPaths;
+            window.showWarningMessage(
+              "Failed to parse CSS variables in files:",
+              `\n\n${relativePaths.join("\n\n")}`
+            );
+          }
+        });
 
-      watcher.onDidDelete(uri => {
-        // THough I don't think this is of any benefit.
-        CACHE.filesToWatch.delete(uri.fsPath);
-      });
+        watcher.onDidDelete(uri => {
+          // Though I don't think this is of any benefit.
+          CACHE.filesToWatch[folder.uri.fsPath].delete(uri.fsPath);
+        });
 
-      watchers.push(watcher);
+        watchers.push(watcher);
+      }
     }
+    //#endregion
+
+    context.subscriptions.push(
+      window.onDidChangeActiveTextEditor(updateStatus)
+    );
   } catch (err) {
     if (err instanceof Error) {
       window.showErrorMessage(err.message);
-      LOGGER.warn(err);
+      LOGGER.warn("Failed to Activate extension: ", err);
     }
   }
 }
@@ -94,4 +108,20 @@ export function deactivate(): void {
   watchers.forEach(watcher => {
     watcher.dispose();
   });
+}
+
+/**
+ * References:
+ *  - https://github.com/microsoft/vscode-extension-samples/blob/main/basic-multi-root-sample/src/extension.ts
+ *  - https://github.com/Microsoft/vscode-extension-samples/blob/main/configuration-sample/src/extension.ts
+ */
+function updateStatus(event: TextEditor | undefined) {
+  if (event) {
+    if (Object.prototype.hasOwnProperty.call(event, "document")) {
+      const rootPath =
+        workspace.getWorkspaceFolder((<TextEditor>event).document.uri)?.uri
+          .fsPath || CACHE.activeRootPath;
+      CACHE.activeRootPath = rootPath;
+    }
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,6 @@ import {
 } from "vscode";
 import { resolve } from "path";
 import fastGlob from "fast-glob";
-import { NoWorkspaceError } from "./errors";
 import {
   CACHE,
   Config,
@@ -40,19 +39,11 @@ const getConfigValue = <T extends keyof Config>(
 };
 
 /**
- * Sets up the Plugin
- *
- * TODO(shub): Cache config, to use it in places, where initial
- *  configuration is required.
- *
- * @throws {@link NoWorkspaceError}
+ * Initializes the Plugin
  */
 export async function setup(): Promise<{
   config: { [fsPath: string]: Config };
 }> {
-  if (!workspace.workspaceFolders) {
-    throw new NoWorkspaceError("No Workspace found.");
-  }
   const workspaceFolders = workspace.workspaceFolders || [];
   const firstFolderPath = workspaceFolders[0]?.uri.fsPath;
   const config = {} as { [fsPath: string]: Config };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -28,12 +28,12 @@ import { LOGGER } from "./logger";
 const readFileAsync = promisify(readFile);
 const statAsync = promisify(stat);
 
-const cssParseAsync = (file: string, ext: CssExtensions) => {
+const cssParseAsync = (file: string, ext: CssExtensions, rootPath: string) => {
   const rootPaths =
     workspace.workspaceFolders?.map(folder => folder.uri.fsPath) || [];
   const rootPathsOrUndefined = rootPaths.length === 0 ? undefined : rootPaths;
 
-  const plugins = CACHE.config[CACHE.activeRootPath].postcssPlugins
+  const plugins = CACHE.config[rootPath].postcssPlugins
     .map(plugin => {
       try {
         const resolvedMod = require(require.resolve(plugin, {
@@ -51,11 +51,11 @@ const cssParseAsync = (file: string, ext: CssExtensions) => {
     .filter(Boolean);
 
   /* Postcss Syntax needs to be applied only for files of that type */
-  const syntaxModuleName = CACHE.config[
-    CACHE.activeRootPath
-  ].postcssSyntax.find(moduleName => {
-    return moduleName === POSTCSS_SYNTAX_MODULES[ext];
-  });
+  const syntaxModuleName = CACHE.config[rootPath].postcssSyntax.find(
+    moduleName => {
+      return moduleName === POSTCSS_SYNTAX_MODULES[ext];
+    }
+  );
 
   const options: ProcessOptions = {
     from: undefined,
@@ -186,7 +186,8 @@ const parseFile = async function (
   const extension = extname(path);
   const css = await cssParseAsync(
     file,
-    extension.replace(".", "") as CssExtensions
+    extension.replace(".", "") as CssExtensions,
+    rootPath
   );
 
   /* Find imported paths from CSS file */

--- a/src/test/color-provider/color-provider.test.ts
+++ b/src/test/color-provider/color-provider.test.ts
@@ -5,6 +5,7 @@ import { CssColorProvider } from "../../color-provider";
 import { CSSVarDeclarations } from "../../main";
 
 jest.mock("../../constants", () => {
+  const DEFAULT_ROOT_FOLDER = "test";
   const CONSTANTS = jest.requireActual("../../constants");
   const VARIABLES_FILE = "path";
   const cssVariables = [
@@ -30,14 +31,19 @@ jest.mock("../../constants", () => {
     ...CONSTANTS,
     CACHE: {
       ...CONSTANTS.CACHE,
-      cssVars: { [VARIABLES_FILE]: cssVariables },
-      cssVarsMap: cssVariables.reduce(
-        (map, css) => ({ ...map, [css.property]: css }),
-        {}
-      ),
+      cssVars: { [DEFAULT_ROOT_FOLDER]: { [VARIABLES_FILE]: cssVariables } },
+      cssVarsMap: {
+        [DEFAULT_ROOT_FOLDER]: cssVariables.reduce(
+          (map, css) => ({ ...map, [css.property]: css }),
+          {}
+        ),
+      },
+      activeRootPath: DEFAULT_ROOT_FOLDER,
       config: {
-        ...CONSTANTS.DEFAULT_CONFIG,
-        files: [VARIABLES_FILE],
+        [DEFAULT_ROOT_FOLDER]: {
+          ...CONSTANTS.DEFAULT_CONFIG,
+          files: [VARIABLES_FILE],
+        },
       },
     },
   };
@@ -68,7 +74,7 @@ const getDocumentFromText = (text: string) => {
       }
       return null;
     },
-  } as TextDocument
+  } as TextDocument;
 };
 
 describe("Test Color Provider", () => {
@@ -96,7 +102,9 @@ describe("Test Color Provider", () => {
   });
   it("should provide color for multi-line var()", async () => {
     const colorInfos = await provider.provideDocumentColors(
-      getDocumentFromText("color: var(--color-red-300)\ncolor: var(--color-red-500)\ncolor: var(--color-red-700)")
+      getDocumentFromText(
+        "color: var(--color-red-300)\ncolor: var(--color-red-500)\ncolor: var(--color-red-700)"
+      )
     );
     expect(colorInfos.length).toBe(3);
     expect(colorInfos[1].color).toMatchObject({
@@ -109,12 +117,12 @@ describe("Test Color Provider", () => {
       expect.objectContaining({
         start: expect.objectContaining({
           line: 1,
-          character: 7
+          character: 7,
         }),
         end: expect.objectContaining({
           line: 1,
-          character: 27
-        })
+          character: 27,
+        }),
       })
     );
   });

--- a/src/test/css-imports/import.scss
+++ b/src/test/css-imports/import.scss
@@ -8,3 +8,7 @@
 @use "nested/f5";
 
 @import "nested/f6.scss";
+
+:root {
+  --test-var: #333;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,10 +13,11 @@ import {
   SCSS_COLOR_INTERPOLATION,
   SupportedLanguageIds,
   VAR_KEYWORD_REVERSE,
+  CACHE,
 } from "./constants";
 import { CSSVarDeclarations } from "./main";
 import { serializeColor } from "./color-parser";
-import { Range } from "vscode";
+import { Range, window, workspace } from "vscode";
 
 /**
  * [TODO] Change this method to a more generic recursion call to
@@ -315,4 +316,14 @@ export const getCSSErrorMsg = (
     );
   }
   return JSON.stringify(error);
+};
+
+export const getActiveRootPath = (firstFolderPath = CACHE.activeRootPath) => {
+  if (window.activeTextEditor) {
+    return (
+      workspace.getWorkspaceFolder(window.activeTextEditor.document.uri)?.uri
+        .fsPath || firstFolderPath
+    );
+  }
+  return firstFolderPath;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2463,7 +2463,7 @@ esbuild-windows-arm64@0.14.49:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.49.tgz#d83c03ff6436caf3262347cfa7e16b0a8049fae7"
   integrity sha512-v+HYNAXzuANrCbbLFJ5nmO3m5y2PGZWLe3uloAkLt87aXiO2mZr3BTmacZdjwNkNEHuH3bNtN8cak+mzVjVPfA==
 
-esbuild@^0.14.28:
+esbuild@^0.14.49:
   version "0.14.49"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.49.tgz#b82834760eba2ddc17b44f05cfcc0aaca2bae492"
   integrity sha512-/TlVHhOaq7Yz8N1OJrjqM3Auzo5wjvHFLk+T8pIue+fhnhIMpfAzsG6PLVMbFveVxqD2WOp3QHei+52IMUNmCw==
@@ -4700,7 +4700,7 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup-plugin-esbuild@^4.8.2:
+rollup-plugin-esbuild@^4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-esbuild/-/rollup-plugin-esbuild-4.9.1.tgz#369d137e2b1542c8ee459495fd4f10de812666aa"
   integrity sha512-qn/x7Wz9p3Xnva99qcb+nopH0d2VJwVnsxJTGEg+Sh2Z3tqQl33MhOwzekVo1YTKgv+yAmosjcBRJygMfGrtLw==


### PR DESCRIPTION
- This PR also adds examples to help devs figure out how to use this extension settings
- Use `**/*css` as the default file list for parsing. For pure CSS projects, this will make this extension easier to set up, as no settings will be required.
- Improve Extension settings description and example values.