### PR TITLE
[#27][Feat] Add support for Safe Parser

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,10 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "cssvar.ignore": [
+        "**/test/**.css",
+        "**/examples/**",
+        "node_modules/**"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ This extension helps to autocomplete globally shared CSS Variables and a lot mor
 This Extension supports the following properties as of now:
 
 
-| **Setting**                   | **Description**                                              | **Type** | **Example**                                | **Default**                                             |
-|-------------------------------|--------------------------------------------------------------|----------|--------------------------------------------|---------------------------------------------------------|
-| `cssvar.files`                  | Relative/Absolute paths to CSS variable file sources      | string[] | ["input.css"]                           | [**/*.css]                                              |                                                                                                                                                                                                                                                            |
-| `cssvar.ignore`                  | Relative/Absolute paths to file/folder sources to be ignored      | string[] | ["ignore.css"]                           | [\**/node_modules/**]                                              |                                                                                                                                                                                                                                                            |
-| `cssvar.extensions`             | File extensions for which IntelliSense will be enabled    | string[] | [<br>&nbsp;&nbsp;"css",<br>&nbsp;&nbsp;"scss",<br>&nbsp;&nbsp;"jsx"<br>] | [<br>&nbsp;&nbsp;"css",<br>&nbsp;&nbsp;"scss",<br>&nbsp;&nbsp;"tsx",<br>&nbsp;&nbsp;"jsx"<br>]  |
-| `cssvar.themes`<br>Helps to bucket CSS variables based on themes used in any project | CSS Theme classnames used in source files                 | string[] | [<br>&nbsp;&nbsp;"dark",<br>&nbsp;&nbsp;"dim"<br>]             | []                                                      |
-| `cssvar.excludeThemedVariables`<br>If true, hides duplicate theme variables from the list | Exclude themed variables to remove unnecessary duplicates | boolean  |                                            | false                                                   |
-| `cssvar.disableSort`<br>Intellisense list won't be sorted | Disables default sorting applied by VSCode                | boolean  |                                            | false                                                   |
-| `cssvar.enableColors`           | Enable VScode's Color Representation feature when true    | boolean  |                                            | true                                                    |
-| `cssvar.enableGotoDef`          | Enable VScode's Goto Definition feature for CSS Variable  | boolean  |                                            | true                                                    |
-| `cssvar.postcssPlugins`<br>Details for this can be read here: [Customize Extension](./customize-extension.md) | Provide PostCSS Plugins to support custom CSS features    | string[] | ["postcss-nested"]                         | []                                                      |
-| `cssvar.postcssSyntax`<br>Details for this can be read here: [Customize Extension](./customize-extension.md) | Provides a list of custom parsers                                       | string[] | ["postcss-scss"]                           | []                                                      |
+| **Setting**                   | **Description**                                              | **Type** | **Example**                                | **Default**
+|-------------------------------|--------------------------------------------------------------|----------|--------------------------------------------|---------------------------------------------------------
+| `cssvar.files`                  | Relative/Absolute paths to CSS variable file sources      | string[] | ["input.css"]                           | [**/*.css]                                              |
+| `cssvar.ignore`                  | Relative/Absolute paths to file/folder sources to be ignored      | string[] | ["ignore.css"]                           | [\**/node_modules/**]                                              |
+| `cssvar.extensions`             | File extensions for which IntelliSense will be enabled    | string[] | [<br>&nbsp;&nbsp;"css",<br>&nbsp;&nbsp;"scss",<br>&nbsp;&nbsp;"jsx"<br>] | [<br>&nbsp;&nbsp;"css",<br>&nbsp;&nbsp;"scss",<br>&nbsp;&nbsp;"tsx",<br>&nbsp;&nbsp;"jsx"<br>]
+| `cssvar.themes`<br>Helps to bucket CSS variables based on themes used in any project | CSS Theme classnames used in source files                 | string[] | [<br>&nbsp;&nbsp;"dark",<br>&nbsp;&nbsp;"dim"<br>]             | []
+| `cssvar.excludeThemedVariables`<br>If true, hides duplicate theme variables from the list | Exclude themed variables to remove unnecessary duplicates | boolean  |                                            | false
+| `cssvar.disableSort`<br>Intellisense list won't be sorted | Disables default sorting applied by VSCode                | boolean  |                                            | false
+| `cssvar.enableColors`           | Enable VScode's Color Representation feature when true    | boolean  |                                            | true
+| `cssvar.enableGotoDef`          | Enable VScode's Goto Definition feature for CSS Variable  | boolean  |                                            | true
+| `cssvar.postcssPlugins`<br>Details for this can be read here: [Customize Extension](./customize-extension.md) | Provide PostCSS Plugins to support custom CSS features    | string[] | ["postcss-nested"]                         | []
+| `cssvar.postcssSyntax`<br>Details for this can be read here: [Customize Extension](./customize-extension.md) | Provides a list of custom parsers                                       | string[] | ["postcss-scss"]                           | []
 
 
 ## Screeshots:

--- a/examples/safe-parser/.vscode/settings.json
+++ b/examples/safe-parser/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cssvar.files": ["source.*"]
+}

--- a/examples/safe-parser/index.css
+++ b/examples/safe-parser/index.css
@@ -1,0 +1,7 @@
+.app {
+  color: var(--color-js-1);
+  background-color: var(--color-tsx-2);
+  padding: var(--space-1);
+  border-color: var(--brand-2);
+  color: var(--color-astro-1);
+}

--- a/examples/safe-parser/source.astro
+++ b/examples/safe-parser/source.astro
@@ -1,0 +1,48 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Card from "../components/Card.astro";
+---
+
+<Layout title="Welcome to Astro.">
+	<main>
+		<h1>Welcome to <span class="text-gradient">Astro</span></h1>
+		<p class="instructions">
+			Check out the <code>src/pages</code> directory to get started.<br />
+			<strong>Code Challenge:</strong> Tweak the "Welcome to Astro" message above.
+		</p>
+		<ul role="list" class="link-card-grid">
+			<Card
+				href="https://docs.astro.build/"
+				title="Documentation"
+				body="Learn how Astro works and explore the official API docs."
+			/>
+			<Card
+				href="https://astro.build/integrations/"
+				title="Integrations"
+				body="Supercharge your project with new frameworks and libraries."
+			/>
+			<Card
+				href="https://astro.build/themes/"
+				title="Themes"
+				body="Explore a galaxy of community-built starter themes."
+			/>
+			<Card
+				href="https://astro.build/chat/"
+				title="Chat"
+				body="Come say hi to our amazing Discord community. ❤️"
+			/>
+		</ul>
+	</main>
+</Layout>
+
+<style>
+	:root {
+    --color-astro-1: #ddaa99;
+    --color-astro-2: #5599cc;
+		--astro-gradient: linear-gradient(0deg, #4f39fa, #da62c4);
+	}
+
+	h1 {
+		margin: 2rem 0;
+	}
+</style>

--- a/examples/safe-parser/source.jsx
+++ b/examples/safe-parser/source.jsx
@@ -1,0 +1,26 @@
+import { styled, css } from "styled-components";
+
+export const Button = styled.a`
+  :root {
+    --color-js-1: #f30;
+    --color-js-2: #f0aa44;
+  }
+  /* This renders the buttons above... Edit me! */
+  display: inline-block;
+  border-radius: 3px;
+  padding: 0.5rem 0;
+  margin: 0.5rem 1rem;
+  width: 11rem;
+  background: transparent;
+  color: white;
+  border: 2px solid white;
+
+  /* The GitHub button is a primary button
+   * edit this to target it specifically! */
+  ${props =>
+    props.primary &&
+    css`
+      background: white;
+      color: black;
+    `}
+`;

--- a/examples/safe-parser/source.scss
+++ b/examples/safe-parser/source.scss
@@ -1,0 +1,24 @@
+// Single line comments is not supported in CSS.
+$color-1: #FF8A65;
+$color-2: #8D6E63;
+$color-3: #BDBDBD;
+
+:root {
+  --space-1: 1rem;
+  --space-2: 2rem;
+  // This is a little broken, since safe-parser considers
+  // #{$color-1} as a separate rule. LOL!! Adding a single
+  // line comments completely loses the following variable
+
+  --brand-1: #{$color-1};
+  --brand-2: #{$color-2};
+  --brand-3: #{$color-3};
+}
+
+.app {
+  // Nested rules are not supported in CSS
+  .child {
+    color: var(--brand-1);
+    background-color: var(--brand-3);
+  }
+}

--- a/examples/safe-parser/source.tsx
+++ b/examples/safe-parser/source.tsx
@@ -1,0 +1,14 @@
+// @ts-ignore
+import { styled } from "styled-components";
+
+// For now variables inside some rules are only getting parsed
+export const Title = styled.h1`
+  --color-tsx-1: #34aa12;
+  .child {
+    --color-tsx-2: #aa2399;
+  }
+  /* Text centering won't break if props.upsidedown is falsy */
+  ${props => props.upsidedown && "transform: rotate(180deg);"}
+  ${props => props.upsidedown && "--wont-work: #334;"}
+  text-align: center;
+`;

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "@types/jest": "^26.0.24",
     "@types/lodash": "^4.14.180",
     "@types/node": "^12.20.47",
+    "@types/postcss-safe-parser": "^5.0.1",
     "@types/vscode": "1.46.0",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
@@ -248,7 +249,8 @@
   "dependencies": {
     "culori": "^2.0.3",
     "fast-glob": "^3.2.11",
-    "postcss": "^8.4.12"
+    "postcss": "^8.4.12",
+    "postcss-safe-parser": "^6.0.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8,6 +8,7 @@ import postcss, {
   ProcessOptions,
   Rule,
 } from "postcss";
+import safeParser from "postcss-safe-parser";
 import { promisify } from "util";
 import {
   CACHE,
@@ -59,6 +60,7 @@ const cssParseAsync = (file: string, ext: CssExtensions, rootPath: string) => {
 
   const options: ProcessOptions = {
     from: undefined,
+    parser: safeParser,
     syntax: undefined,
   };
   if (syntaxModuleName) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -60,7 +60,7 @@ const cssParseAsync = (file: string, ext: CssExtensions, rootPath: string) => {
 
   const options: ProcessOptions = {
     from: undefined,
-    parser: safeParser,
+    parser: syntaxModuleName ? undefined : safeParser,
     syntax: undefined,
   };
   if (syntaxModuleName) {

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -146,7 +146,7 @@ describe("Test Parser", () => {
         value: "#f00",
       } as CSSVarDeclarations);
       expect(CACHE.cssVars[CACHE.activeRootPath][BROKEN_FILE].length).toBe(0);
-      expect(errorPaths[0]).toBe(BROKEN_FILE);
+      expect(errorPaths.length).toBe(0);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,6 +1428,13 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/postcss-safe-parser@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/postcss-safe-parser/-/postcss-safe-parser-5.0.1.tgz#c4e8385f089f54cc8df4c10df3fe24449b6593ef"
+  integrity sha512-/yt27wx9N+HmpCAUS/Wyk1d17qFCmi8cYAnIDar0U0jO4QMG1UFqsvVhg7Cy4xjmEAfAzeyBJmXH5Sti4/fDOQ==
+  dependencies:
+    postcss "^8.4.4"
+
 "@types/prettier@^2.0.0":
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"
@@ -4442,12 +4449,17 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==
 
+postcss-safe-parser@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
+  integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
+
 postcss-scss@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.4.tgz#aa8f60e19ee18259bc193db9e4b96edfce3f3b1f"
   integrity sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==
 
-postcss@^8.4.12:
+postcss@^8.4.12, postcss@^8.4.4:
   version "8.4.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
   integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==


### PR DESCRIPTION
This is a big change, to support safe parsers. In future, this extension would have its own parser for CSS variables supporting any extension.

- Safe Parser triggers only for extensions whose parser is not provided.
- To get accurate parsed data, a syntax parser is still required.
  - I want to create a generic parser for CSS variables so that syntax parser dependency can be removed entirely.

This change is not breaking in nature.

> Usage for safe parser may or may not work properly for unsupported extensions, like `jsx`, `tsx`, `vue` etc.
Future updates will fix that.