### PR TITLE
[Feat] Support remote CSS file urls in settings

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -8,8 +8,6 @@
 - `statsSync` used for cache invalidation needs to be improvised for failure cases
   - This can happen when a file is deleted and does not exist anymore.
 - Add compatibility with https://github.com/enyancc/vscode-ext-color-highlight
-- Test if `/tmp` files from ` /var/folders/cy/sn2s2ttx7mndbf4mbwffxb500000gn/T//cssvar` got deleted after
-  3-30days or not!!
 - Precached files in file watcher, once removed from source css files (like from @import paths)
   still stays cached. Steps to reproduce:
   - Open `css-imports` project -> After the files are parsed, update any import for `open-props` with a new

--- a/TASKS.md
+++ b/TASKS.md
@@ -8,6 +8,13 @@
 - `statsSync` used for cache invalidation needs to be improvised for failure cases
   - This can happen when a file is deleted and does not exist anymore.
 - Add compatibility with https://github.com/enyancc/vscode-ext-color-highlight
+- Test if `/tmp` files from ` /var/folders/cy/sn2s2ttx7mndbf4mbwffxb500000gn/T//cssvar` got deleted after
+  3-30days or not!!
+- Precached files in file watcher, once removed from source css files (like from @import paths)
+  still stays cached. Steps to reproduce:
+  - Open `css-imports` project -> After the files are parsed, update any import for `open-props` with a new
+    granular css import, like `open-props/red.min.css`.
+  - Doing this still shows `open-props/open-props.min.css` in the autocomplete/definition-provider list.
 
 
 ## Notes:

--- a/examples/css-imports/.vscode/settings.json
+++ b/examples/css-imports/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cssvar.files": [
+    "*.css",
+    "https://unpkg.com/open-props@1.4.14/violet.min.css"
+  ]
+}

--- a/examples/css-imports/index.css
+++ b/examples/css-imports/index.css
@@ -1,0 +1,21 @@
+@import './local.css';
+
+/* Following is very specific to webpack/react projects */
+/* I won't be supporting this in this extension, as a user can import */
+/* such css files from extension settings */
+/* @import '~open-props/open-props.min.css' */
+
+@import 'node_modules/open-props/open-props.min.css';
+
+/* Following import syntax is supported by vite projects */
+/* Again this is very bundler specific and will not be supported */
+/* @import 'pollen-css/pollen.css'; */
+
+@import url(https://unpkg.com/pollen-css@4.4.0/pollen.css);
+
+body {
+  color: var(--red-2);
+  padding: var(--gap-md);
+  border-color: var(--color-red);
+  grid-template-columns: var(--grid-page);
+}

--- a/examples/css-imports/index.css
+++ b/examples/css-imports/index.css
@@ -1,3 +1,10 @@
+/**
+ * The extension will cache all remote url imports, irrespective of them having
+ * any CSS variables or not. The files are stored in `$TMPDIR/cssvar` temp folder
+ * if you ever want to manually remove them. These files will automatically be
+ * cleaned up by your OS, if not used for a specific period of time or after a reboot.
+ */
+@import "https://cdn.jsdelivr.net/npm/modern-normalize@1.1.0/modern-normalize.min.css";
 @import './local.css';
 
 /* Following is very specific to webpack/react projects */
@@ -5,7 +12,7 @@
 /* such css files from extension settings */
 /* @import '~open-props/open-props.min.css' */
 
-@import 'node_modules/open-props/open-props.min.css';
+@import url('node_modules/open-props/red.min.css') layer(utilities) print, screen;
 
 /* Following import syntax is supported by vite projects */
 /* Again this is very bundler specific and will not be supported */
@@ -15,7 +22,10 @@
 
 body {
   color: var(--red-2);
+  width: var(--width-sm);
   padding: var(--gap-md);
   border-color: var(--color-red);
   grid-template-columns: var(--grid-page);
+  background-color: var(--c-blue);
+  border-top-color: var(--orange-2);
 }

--- a/examples/css-imports/index.css
+++ b/examples/css-imports/index.css
@@ -28,4 +28,5 @@ body {
   grid-template-columns: var(--grid-page);
   background-color: var(--c-blue);
   border-top-color: var(--orange-2);
+  box-shadow: 0 0 3px 0 var(--violet-2);
 }

--- a/examples/css-imports/local.css
+++ b/examples/css-imports/local.css
@@ -1,0 +1,7 @@
+:root {
+  --gap-sm: 0.25rem;
+  --gap-md: 0.5rem;
+  --gap-lg: 1rem;
+  --gap-xl: 2rem;
+  --gap-xxl: 4rem;
+}

--- a/examples/css-imports/local.css
+++ b/examples/css-imports/local.css
@@ -1,3 +1,6 @@
+@import url("https://unpkg.com/open-props@1.4.14/orange.min.css");
+@import url(./nested.css);
+
 :root {
   --gap-sm: 0.25rem;
   --gap-md: 0.5rem;

--- a/examples/css-imports/nested.css
+++ b/examples/css-imports/nested.css
@@ -1,0 +1,5 @@
+:root {
+  --c-red: red;
+  --c-green: green;
+  --c-blue: blue;
+}

--- a/examples/css-imports/package.json
+++ b/examples/css-imports/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "css-imports",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "open-props": "^1.4.14",
+    "pollen-css": "^4.4.0"
+  }
+}

--- a/examples/css-imports/pnpm-lock.yaml
+++ b/examples/css-imports/pnpm-lock.yaml
@@ -1,0 +1,214 @@
+lockfileVersion: 5.4
+
+specifiers:
+  open-props: ^1.4.14
+  pollen-css: ^4.4.0
+
+dependencies:
+  open-props: 1.4.14
+  pollen-css: 4.4.0
+
+packages:
+
+  /@babel/code-frame/7.18.6:
+    resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.18.6
+    dev: false
+
+  /@babel/helper-validator-identifier/7.18.6:
+    resolution: {integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/highlight/7.18.6:
+    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.18.6
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: false
+
+  /@types/parse-json/4.0.0:
+    resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+    dev: false
+
+  /ansi-styles/3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
+    dev: false
+
+  /balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: false
+
+  /callsites/3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /case/1.6.3:
+    resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
+    engines: {node: '>= 0.8.0'}
+    dev: false
+
+  /chalk/2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+    dev: false
+
+  /color-convert/1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+    dev: false
+
+  /color-name/1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    dev: false
+
+  /commander/9.4.0:
+    resolution: {integrity: sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==}
+    engines: {node: ^12.20.0 || >=14}
+    dev: false
+
+  /cosmiconfig/7.0.1:
+    resolution: {integrity: sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@types/parse-json': 4.0.0
+      import-fresh: 3.3.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.2
+    dev: false
+
+  /css-vars-ponyfill/2.4.8:
+    resolution: {integrity: sha512-4/j4AX4htytYHWyHVZ2BFQ+NoCGZEcOH2h4/2mmgE4SkrFg4Xq6tGYR77DtvvUIDsaXuJN+sj41bbgauA0Gfmg==}
+    dependencies:
+      balanced-match: 1.0.2
+      get-css-data: 2.1.0
+    dev: false
+
+  /error-ex/1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+    dependencies:
+      is-arrayish: 0.2.1
+    dev: false
+
+  /escape-string-regexp/1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+    dev: false
+
+  /get-css-data/2.1.0:
+    resolution: {integrity: sha512-HtPrzGk8aBF9rLeQNuImcXci7YVqsMEKzVflEWaCJu25ehxyDNiZRWoSxqSFUBfma8LERqKo70t/TcaGjIsM9g==}
+    dev: false
+
+  /has-flag/3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /import-fresh/3.3.0:
+    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+    engines: {node: '>=6'}
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+    dev: false
+
+  /is-arrayish/0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    dev: false
+
+  /javascript-stringify/2.1.0:
+    resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
+    dev: false
+
+  /js-tokens/4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: false
+
+  /json-parse-even-better-errors/2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    dev: false
+
+  /lines-and-columns/1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    dev: false
+
+  /map-obj/5.0.2:
+    resolution: {integrity: sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
+
+  /open-props/1.4.14:
+    resolution: {integrity: sha512-EkTUczMzty8mIvnWGpC41ELIejARiuljsXTEz7YDRKJn5dJ1/njsLTpNhn2rsM3JSW95p4G94ojsgzxbaiFmNA==}
+    dev: false
+
+  /parent-module/1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+    dependencies:
+      callsites: 3.1.0
+    dev: false
+
+  /parse-json/5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+    dev: false
+
+  /path-type/4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /pollen-css/4.4.0:
+    resolution: {integrity: sha512-BVmTY0/o/WoMCk8rmHBrEYA5bffuehsIAkf1obOq+wzcnwvorNCbKhRFqyTev4RI5+RHOhZMjMe063tEjK8LWg==}
+    hasBin: true
+    dependencies:
+      case: 1.6.3
+      commander: 9.4.0
+      cosmiconfig: 7.0.1
+      css-vars-ponyfill: 2.4.8
+      javascript-stringify: 2.1.0
+      map-obj: 5.0.2
+      prettier: 2.7.1
+    dev: false
+
+  /prettier/2.7.1:
+    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: false
+
+  /resolve-from/4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /supports-color/5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+    dependencies:
+      has-flag: 3.0.0
+    dev: false
+
+  /yaml/1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+    dev: false

--- a/package.json
+++ b/package.json
@@ -331,6 +331,7 @@
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-typescript": "^7.16.7",
     "@rollup/plugin-commonjs": "^18.1.0",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-replace": "^4.0.0",
     "@types/css": "^0.0.31",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "icon": "img/icon.png",
   "engines": {
-    "vscode": "^1.46.0"
+    "vscode": "^1.53.0",
+    "node": "^12.18.3"
   },
   "categories": [
     "Other"
@@ -336,10 +337,10 @@
     "@types/glob": "^7.2.0",
     "@types/jest": "^26.0.24",
     "@types/lodash": "^4.14.180",
-    "@types/node": "18",
+    "@types/node": "12.12.6",
     "@types/postcss-less": "^4.0.2",
     "@types/postcss-safe-parser": "^5.0.1",
-    "@types/vscode": "1.46.0",
+    "@types/vscode": "1.53.0",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
     "babel-jest": "^26.6.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import replace from "@rollup/plugin-replace";
+import json from "@rollup/plugin-json";
 import esbuild from "rollup-plugin-esbuild";
 import pkg from "./package.json";
 import tsConfig from "./tsconfig.json";
@@ -25,6 +26,7 @@ export default [
         ),
         preventAssignment: true,
       }),
+      json(),
       resolve({
         browser: false,
         preferBuiltins: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,8 +47,20 @@ export type JsExtensions = Extract<
   "js" | "jsx" | "ts" | "tsx"
 >;
 
+export type CSSVarLocation = {
+  local: string;
+  remote: string;
+  isRemote: boolean;
+};
+
+/**
+ * Since the inmem config this project maintains is completely diffent than
+ * what user-facing setting types are, it was necessary to separate these two
+ * types into their own.
+ */
 export interface Config {
-  files: string[];
+  files: CSSVarLocation[];
+  // Ignore could be a glob as well.
   ignore: string[];
   extensions: SupportedExtensionNames[];
   themes: string[];
@@ -61,12 +73,16 @@ export interface Config {
   enableHover: boolean;
 }
 
+export type WorkspaceConfig = Omit<Config, "files"> & {
+  files: string[];
+};
+
 /**
  * Remeber(shub):
  *  VSCode's default config settings should always point to null,
  *  because we are programatically overriding VSCode's behaviour.
  */
-export const DEFAULT_CONFIG: Config = {
+export const DEFAULT_CONFIG: WorkspaceConfig = {
   files: ["**/*.css"],
   ignore: ["**/node_modules/**"],
   extensions: [...SUPPORTED_LANGUAGE_IDS],
@@ -112,6 +128,7 @@ export type CacheType = {
   cssVarDefinitionsMap: {
     [activeRootpath: string]: { [varName: string]: Location[] };
   };
+  // Following propety should always point to a local file path
   filesToWatch: { [activeRootpath: string]: Set<string> };
   fileMetas: {
     [path: string]: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -121,6 +121,7 @@ export type CacheType = {
   };
   config: { [activeRootpath: string]: Config };
   activeRootPath: string;
+  tmpDir: string;
 };
 
 export const CACHE: CacheType = {
@@ -131,6 +132,7 @@ export const CACHE: CacheType = {
   fileMetas: {},
   config: {}, // Points to active config.
   activeRootPath: "",
+  tmpDir: "",
 };
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import {
   workspace,
   WorkspaceConfiguration,
 } from "vscode";
+import { tmpdir } from "os";
+import { mkdirSync } from "fs";
 import { resolve } from "path";
 import fastGlob from "fast-glob";
 import {
@@ -54,6 +56,10 @@ export async function setup(): Promise<{
   const config = {} as { [fsPath: string]: Config };
 
   CACHE.activeRootPath = getActiveRootPath(firstFolderPath);
+  if (!CACHE.tmpDir) {
+    CACHE.tmpDir = resolve(tmpdir(), EXTENSION_NAME);
+    mkdirSync(CACHE.tmpDir, { recursive: true });
+  }
 
   for (const folder of workspaceFolders) {
     const _config = workspace.getConfiguration(EXTENSION_NAME, folder.uri);

--- a/src/remote-paths.ts
+++ b/src/remote-paths.ts
@@ -84,6 +84,7 @@ export const fetchAndCacheAsset = (url: string) =>
                     `Premature request termination: ${message.complete}`
                   )
                 );
+                return;
               }
               rej(err);
             });

--- a/src/remote-paths.ts
+++ b/src/remote-paths.ts
@@ -1,0 +1,59 @@
+import { get, IncomingMessage } from "http";
+import { get as sGet } from "https";
+
+//#region Get Fetch, replacement for fetch() Browser API
+// Once VSCode officially starts supporting Node v17.5+
+// I can migrate this code into using `fetch` api :relaxed:
+const CSSGetError = class extends Error {
+  code = 200;
+
+  constructor(response: IncomingMessage, overrideMsg?: string) {
+    super(overrideMsg || response.statusMessage || "CSSGetError: ");
+
+    this.name = "CSSGetError";
+    this.message = overrideMsg || response.statusMessage || "";
+    this.code = response.statusCode || 200;
+  }
+};
+
+export const getFetch = (url: string) =>
+  new Promise<string>((res, rej) => {
+    const _url = new URL(url);
+    let httpGet = sGet;
+
+    if (_url.protocol === "http:") {
+      httpGet = get;
+    }
+
+    httpGet(_url, message => {
+      if (message.statusCode !== 200) {
+        rej(new CSSGetError(message));
+        return;
+      }
+      if (!/text\/css/.test(message.headers["content-type"] || "")) {
+        rej(new CSSGetError(message, "Not a CSS request"));
+        return;
+      }
+
+      let data = "";
+      const complete = () => {
+        if (message.complete) {
+          res(data);
+        } else {
+          rej(
+            new CSSGetError(
+              message,
+              `Premature request termination: ${message.complete}`
+            )
+          );
+        }
+      };
+
+      message.on("data", d => {
+        data += d.toString();
+      });
+      message.on("close", complete);
+      message.on("end", complete);
+    }).on("error", rej);
+  });
+//#endregion

--- a/src/remote-paths.ts
+++ b/src/remote-paths.ts
@@ -1,5 +1,17 @@
+import { createWriteStream, existsSync, mkdirSync, unlink } from "fs";
+import { resolve } from "path";
+import { PassThrough, Readable } from "stream";
 import { get, IncomingMessage } from "http";
 import { get as sGet } from "https";
+import { URL } from "url";
+import {
+  createUnzip,
+  createBrotliDecompress,
+  Unzip,
+  BrotliDecompress,
+} from "zlib";
+import { version } from "../package.json";
+import { CACHE } from "./constants";
 
 //#region Get Fetch, replacement for fetch() Browser API
 // Once VSCode officially starts supporting Node v17.5+
@@ -25,35 +37,86 @@ export const getFetch = (url: string) =>
       httpGet = get;
     }
 
-    httpGet(_url, message => {
-      if (message.statusCode !== 200) {
-        rej(new CSSGetError(message));
-        return;
-      }
-      if (!/text\/css/.test(message.headers["content-type"] || "")) {
-        rej(new CSSGetError(message, "Not a CSS request"));
-        return;
-      }
-
-      let data = "";
-      const complete = () => {
-        if (message.complete) {
-          res(data);
-        } else {
-          rej(
-            new CSSGetError(
-              message,
-              `Premature request termination: ${message.complete}`
-            )
-          );
+    httpGet(
+      _url,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          "user-agent": `cssvar/${version}`,
+          "accept-encoding": "deflate, gzip, br",
+        },
+      },
+      message => {
+        if (message.statusCode !== 200) {
+          rej(new CSSGetError(message));
+          return;
         }
-      };
+        if (!/text\/css/.test(message.headers["content-type"] || "")) {
+          rej(new CSSGetError(message, "Not a CSS request"));
+          return;
+        }
 
-      message.on("data", d => {
-        data += d.toString();
-      });
-      message.on("close", complete);
-      message.on("end", complete);
-    }).on("error", rej);
+        const pathTokens = _url.pathname.split("/");
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const filename = pathTokens.pop()!;
+        const parentpath = resolve(CACHE.tmpDir, ...pathTokens);
+        const filepath = resolve(parentpath, filename);
+
+        if (!existsSync(parentpath)) {
+          mkdirSync(parentpath, { recursive: true });
+        }
+
+        let inmemContent = "";
+        const data = createWriteStream(filepath, { encoding: "utf-8" });
+        const tunnel = new PassThrough();
+        const checkFailure = () => {
+          if (!message.complete) {
+            /**
+             * It is important to cleanup/remove cached files if request
+             * somehow exited before properly writing to the file
+             */
+            unlink(filepath, err => {
+              if (!err) {
+                rej(
+                  new CSSGetError(
+                    message,
+                    `Premature request termination: ${message.complete}`
+                  )
+                );
+              }
+              rej(err);
+            });
+          }
+        };
+
+        const encoding = message.headers["content-encoding"];
+        let decompressorPipe: Unzip | BrotliDecompress | null = null;
+        switch (encoding) {
+          case "gzip":
+          case "deflate":
+            decompressorPipe = createUnzip();
+            break;
+          case "br":
+            decompressorPipe = createBrotliDecompress();
+            break;
+          default:
+        }
+
+        let decompressedPipe: Readable = message;
+        if (decompressorPipe) {
+          decompressedPipe = message.pipe(decompressorPipe);
+        }
+
+        decompressedPipe.pipe(tunnel).pipe(data);
+
+        tunnel.on("data", d => {
+          inmemContent += d.toString();
+        });
+        message.on("close", checkFailure);
+        message.on("end", checkFailure);
+        data.on("close", () => res(inmemContent));
+        data.on("error", rej);
+      }
+    ).on("error", rej);
   });
 //#endregion

--- a/src/test/main.test.ts
+++ b/src/test/main.test.ts
@@ -2,6 +2,7 @@ import { Position, Range } from "vscode";
 import { Config, CSSVarRecord, DEFAULT_CONFIG } from "../constants";
 import { createCompletionItems } from "../main";
 import { Region } from "../utils";
+import { getLocalCSSVarLocation } from "./test-utilities";
 
 jest.mock("../constants", () => ({
   ...jest.requireActual("../constants"),
@@ -25,6 +26,11 @@ describe("Test Extension Main", () => {
     it("Should return CompletionItems with Sorting On", async () => {
       const config: Config = {
         ...DEFAULT_CONFIG,
+        files: [{
+          local: "",
+          remote: "",
+          isRemote: false,
+        }],
         disableSort: false,
       }
       const cssVars: CSSVarRecord = {
@@ -61,6 +67,11 @@ describe("Test Extension Main", () => {
     it("Should return CompletionItems with Sorting Disabled", async () => {
       const config: Config = {
         ...DEFAULT_CONFIG,
+        files: [{
+          local: "",
+          remote: "",
+          isRemote: false,
+        }],
         disableSort: true,
       }
       const cssVars: CSSVarRecord = {
@@ -100,6 +111,7 @@ describe("Test Extension Main", () => {
     it("Should return CompletionItems with 3 and 2digit sortText", async () => {
       const config: Config = {
         ...DEFAULT_CONFIG,
+        files: [getLocalCSSVarLocation("")],
         disableSort: true,
       }
       const cssVars1: CSSVarRecord = Array(11)

--- a/src/test/pre-processors/template-literals.test.ts
+++ b/src/test/pre-processors/template-literals.test.ts
@@ -1,8 +1,8 @@
 import { resolve } from "path";
-import fs from "fs";
-import preProcessContent, { JS_BLOCK } from "../../pre-processors";
+import { JS_BLOCK } from "../../pre-processors";
 import { parseFiles } from "../../parser";
 import { CACHE, Config, CSSVarRecord, DEFAULT_CONFIG } from "../../constants";
+import { getLocalCSSVarLocation } from "../test-utilities";
 
 jest.mock("../../constants", () => {
   const CONSTANTS = jest.requireActual("../../constants");
@@ -25,7 +25,7 @@ const JSX_FILE_PATH = resolve(__dirname, "..", "fixtures", "edge-cases.jsx");
 const MOCK_CONFIG: ConfigRecord = {
   [CACHE.activeRootPath]: {
     ...DEFAULT_CONFIG,
-    files: [JSX_FILE_PATH],
+    files: [getLocalCSSVarLocation(JSX_FILE_PATH)],
   },
 };
 

--- a/src/test/test-utilities.ts
+++ b/src/test/test-utilities.ts
@@ -1,0 +1,8 @@
+import { CSSVarLocation } from "../constants";
+
+export const getLocalCSSVarLocation = (path: string) =>
+  ({
+    local: path,
+    remote: "",
+    isRemote: false,
+  } as CSSVarLocation);

--- a/src/test/theming-and-duplicates.test.ts
+++ b/src/test/theming-and-duplicates.test.ts
@@ -2,6 +2,7 @@ import { parseFiles } from "../parser";
 import path from "path";
 
 import { Config, DEFAULT_CONFIG, CACHE } from "../constants";
+import { getLocalCSSVarLocation } from "./test-utilities";
 
 const THEMING_CSS = path.resolve("src", "test", "fixtures", "theming.css");
 
@@ -23,7 +24,7 @@ type ConfigRecord = { [rootFolder: string]: Config };
 const CONFIG: ConfigRecord = {
   [CACHE.activeRootPath]: {
     ...DEFAULT_CONFIG,
-    files: [THEMING_CSS],
+    files: [getLocalCSSVarLocation(THEMING_CSS)],
   },
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,7 @@ import { serializeColor } from "./color-parser";
 import { Range, window, workspace } from "vscode";
 import { URL } from "url";
 import { resolve } from "path";
+import { existsSync } from "fs";
 
 /**
  * [TODO] Change this method to a more generic recursion call to
@@ -336,4 +337,15 @@ export const getCachedRemoteFilePath = (url: URL) => {
   const filename = pathTokens.pop()!;
   const parentpath = resolve(CACHE.tmpDir, ...pathTokens);
   return [parentpath, resolve(parentpath, filename)];
+};
+
+export const getRemoteCSSVarLocation = (url: string) => {
+  const tmpFilePath = getCachedRemoteFilePath(new URL(url))[1];
+  const alreadyCached = existsSync(tmpFilePath);
+  return {
+    local: getCachedRemoteFilePath(new URL(url))[1],
+    remote: url,
+    // Consider the URL to be local, if it's already cached
+    isRemote: !alreadyCached,
+  };
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,8 @@ import {
 import { CSSVarDeclarations } from "./main";
 import { serializeColor } from "./color-parser";
 import { Range, window, workspace } from "vscode";
+import { URL } from "url";
+import { resolve } from "path";
 
 /**
  * [TODO] Change this method to a more generic recursion call to
@@ -326,4 +328,12 @@ export const getActiveRootPath = (firstFolderPath = CACHE.activeRootPath) => {
     );
   }
   return firstFolderPath;
+};
+
+export const getCachedRemoteFilePath = (url: URL) => {
+  const pathTokens = url.pathname.split("/");
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const filename = pathTokens.pop()!;
+  const parentpath = resolve(CACHE.tmpDir, ...pathTokens);
+  return [parentpath, resolve(parentpath, filename)];
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,10 @@
 			"esnext"
 		],
 		"sourceMap": true,
-		"rootDir": "src",
 		"strict": true,
 		"esModuleInterop": true,
-		"strictNullChecks": true
+		"strictNullChecks": true,
+		"resolveJsonModule": true
 	},
 	"include": [
 		"src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,6 +1247,13 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
+"@rollup/plugin-json@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
+  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+
 "@rollup/plugin-node-resolve@^11.2.1":
   version "11.2.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz#82aa59397a29cd4e13248b106e6a4a1880362a60"
@@ -1267,7 +1274,7 @@
     "@rollup/pluginutils" "^3.1.0"
     magic-string "^0.25.7"
 
-"@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,10 +1413,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.6.tgz#0ba49ac517ad69abe7a1508bc9b3a5483df9d5d7"
   integrity sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==
 
-"@types/node@18":
-  version "18.7.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.14.tgz#0fe081752a3333392d00586d815485a17c2cf3c9"
-  integrity sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==
+"@types/node@12.12.6":
+  version "12.12.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.6.tgz#a47240c10d86a9a57bb0c633f0b2e0aea9ce9253"
+  integrity sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1459,10 +1459,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/vscode@1.46.0":
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.46.0.tgz#53f2075986e901ed25cd1ec5f3ffa5db84a111b3"
-  integrity sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==
+"@types/vscode@1.53.0":
+  version "1.53.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.53.0.tgz#47b53717af6562f2ad05171bc9c8500824a3905c"
+  integrity sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==
 
 "@types/yargs-parser@*":
   version "21.0.0"


### PR DESCRIPTION
Closes #63 

## What's new

- Downloads CSS remote files when used either in `cssvar.files` settings or in `@import` rule.
- The parser can recursively fetch all remote imports.
- Support for caching downloaded CSS remote files, to make subsequent extension load times faster.