### PR TITLE
[Feat] Allow users to enable/disable css variable linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,180 +108,16 @@ Limited support to keep bundle size small.
 Except for `color(`)` api, every other CSS color is supported.
 Please find details for CSS colors [here in MDN Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)
 
-<br/><br/>
+<br>
 
-## 🛠 Supported Configs:
+## 🔖 Appendix:
 
-This Extension supports the following properties as of now:
+- [Extension setting details][settings-link]
+- [Extension Customization][customize-extension-link]
+- [Theming Support][theme-link]
+- [Debugging the extension][debug-link]
 
-
-<table>
-<thead>
-  <tr align="left">
-    <th><b>Setting</b></th>
-    <th><b>Description</b></th>
-    <th><b>Type</b></th>
-    <th><b>Default</b></th>
-  </tr>
-</thead>
-<tbody>
-  <tr align="left">
-    <td><code>cssvar.files</code></td>
-    <td>
-      Relative/Absolute paths to CSS variable source files
-    </td>
-    <td><code>string[]</code></td>
-    <td><br>
-      <pre lang="js">["**/*.css"]</pre>
-      <br>
-    </td>
-  </tr>
-  <tr align="left">
-    <td><code>cssvar.ignore</code></td>
-    <td>
-      Relative/Absolute paths to file/folder sources to be ignored
-    </td>
-    <td><code>string[]</code></td>
-    <td><br>
-      <pre lang="js">["**/node_modules/**"]</pre>
-      <br>
-    </td>
-  </tr>
-  <tr align="left">
-    <td><code>cssvar.extensions</code></td>
-    <td>File extensions in which IntelliSense will be enabled</td>
-    <td><code>string[]</code></td>
-    <td>
-      <br>
-      <pre lang="js">[
-  "css",
-  "scss",
-  "sass",
-  "less",
-  "postcss",
-  "vue",
-  "svelte",
-  "astro",
-  "ts",
-  "tsx",
-  "js",
-  "jsx"
-]</pre>
-      <br>
-    </td>
-  </tr>
-  <tr align="left">
-    <td>
-      <code>cssvar.themes</code>
-      <br>Helps to bucket CSS variables based on themes used in any project
-    </td>
-    <td>
-      <br>CSS Theme class names used in source files
-      <br>E.g.<pre lang="js">["dark","dim"]</pre>
-    </td>
-    <td><code>string[]</code></td>
-    <td>
-      <br>
-      <pre lang="js">[]</pre>
-      <br>
-    </td>
-  </tr>
-  <tr align="left">
-    <td>
-      <code>cssvar.excludeThemedVariables</code>
-      <br>If <code>true</code>, hides duplicate theme variables from the list
-    </td>
-    <td>Exclude themed variables to remove unnecessary duplicates</td>
-    <td><code>boolean</code></td>
-    <td>
-      <br>
-      <pre lang="js">false</pre>
-      <br>
-    </td>
-  </tr>
-  <tr align="left">
-    <td>
-      <code>cssvar.disableSort</code>
-      <br>Intellisense list won't be sorted
-    </td>
-    <td>Disables default sorting applied by VSCode</td>
-    <td><code>boolean</code></td>
-    <td>
-      <br>
-      <pre lang="js">false</pre>
-      <br>
-    </td>
-  </tr>
-  <tr align="left">
-    <td><code>cssvar.enableColors</code></td>
-    <td>Enable VSCode's Color Representation feature when <code>true</code></td>
-    <td><code>boolean</code></td>
-    <td>
-      <br>
-      <pre lang="js">true</pre>
-      <br>
-    </td>
-  </tr>
-  <tr align="left">
-    <td><code>cssvar.enableGotoDef</code></td>
-    <td>Enable VSCode's Goto Definition feature for CSS Variable</td>
-    <td><code>boolean</code></td>
-    <td>
-      <br>
-      <pre lang="js">true</pre>
-      <br>
-    </td>
-  </tr>
-  <tr align="left">
-    <td><code>cssvar.enableHover</code></td>
-    <td>Enable VScode's Hover IntelliSense feature for CSS Variables</td>
-    <td><code>boolean</code></td>
-    <td>
-      <br>
-      <pre lang="js">true</pre>
-      <br>
-    </td>
-  </tr>
-  <tr align="left">
-    <td>
-      <code>cssvar.postcssSyntax</code>
-      <br>Details for this can be read here: <a href="./docs/customize-extension.md">Customize Extension</a>
-    </td>
-    <td>
-      <br>Provides custom syntax parser for the mapped file extensions.
-      <br>E.g.<pre lang="js">{
-  "sugarss": ["sss"]
-}</pre>
-    </td>
-    <td><code>Record&lt;string,string[]<br>&gt;</code></td>
-    <td>
-      <br>
-      <pre lang="js">{}</pre>
-      <br>
-    </td>
-  </tr>
-  <tr align="left">
-    <td>
-      <code>cssvar.postcssPlugins</code>
-    </td>
-    <td>
-      <br>Provide PostCSS Plugins to support custom CSS features
-      <br>E.g.<pre lang="js">["postcss-nested"]</pre>
-    </td>
-    <td><code>string[]</code></td>
-    <td>
-      <br>
-      <pre lang="js">[]</pre>
-      <br>
-    </td>
-  </tr>
-</tbody>
-</table>
-<br/><br/>
-
-> NOTE: Please [raise an issue](https://github.com/willofindie/vscode-cssvar/issues/new) for any feature request or a bug fix.
-
----
+<br><br><br><br>
 
 <h3 align="center">Phoenisx Sponsors</h3>
 
@@ -293,5 +129,8 @@ This Extension supports the following properties as of now:
 
 
 
+
+[settings-link]: ./feature-contributions.md
 [customize-extension-link]: ./docs/customize-extension.md
 [theme-link]: ./docs/theming.md
+[debug-link]: ./docs/debug-extension.md

--- a/__mocks__/vscode.js
+++ b/__mocks__/vscode.js
@@ -93,6 +93,14 @@ class Color {
   }
 }
 
+class Diagnostic {
+  constructor(range, desc, severity) {
+    this.range = range;
+    this.desc = desc;
+    this.severity = severity;
+  }
+}
+
 const workspace = {
   getConfiguration: jest.fn(),
   workspaceFolders: [],
@@ -151,4 +159,9 @@ module.exports = {
   },
   Uri,
   RelativePattern,
+  DiagnosticSeverity: {
+    Error: 0,
+    Warning: 1,
+  },
+  Diagnostic,
 };

--- a/__mocks__/vscode.js
+++ b/__mocks__/vscode.js
@@ -38,7 +38,26 @@ class Position {
     if (line === this.line && char === this.char) {
       return this;
     } else {
+      if (
+        typeof line === "object" &&
+        Object.prototype.hasOwnProperty.call(line, "line")
+      ) {
+        const { line: _line, character } = line;
+        return new Position(_line, character);
+      }
       return new Position(line, char);
+    }
+  });
+
+  translate = jest.fn().mockImplementation(change => {
+    if (typeof change !== "object") {
+      return this;
+    } else {
+      const { lineDelta, characterDelta } = change;
+      return new Position(
+        this.line + lineDelta,
+        this.character + characterDelta
+      );
     }
   });
 }
@@ -78,6 +97,8 @@ const workspace = {
   getConfiguration: jest.fn(),
   workspaceFolders: [],
   onDidSaveTextDocument: jest.fn(),
+  onDidChangeTextDocument: jest.fn(),
+  onDidCloseTextDocument: jest.fn(),
   createFileSystemWatcher: jest.fn().mockReturnValue({
     onDidChange: jest.fn(),
     onDidDelete: jest.fn(),
@@ -89,6 +110,7 @@ const languages = {
   registerColorProvider: jest.fn((_, obj) => obj),
   registerDefinitionProvider: jest.fn((_, obj) => obj),
   registerHoverProvider: jest.fn((_, obj) => obj),
+  createDiagnosticCollection: jest.fn((_, obj) => obj),
 };
 
 const window = {

--- a/examples/multi-root/proj-1/index.css
+++ b/examples/multi-root/proj-1/index.css
@@ -5,5 +5,8 @@
 
 .app {
   color: var(--color-1);
-  background-color: var(--color-1);
+  background-color: var(--color-2);
+
+  /* Non declared variable test */
+  color: var(--space-2, 2rem);
 }

--- a/examples/multi-root/proj-2/.vscode/settings.json
+++ b/examples/multi-root/proj-2/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
   "cssvar.files": ["**/*.scss"],
+  "cssvar.mode": "warn"
 }

--- a/examples/multi-root/proj-2/index.scss
+++ b/examples/multi-root/proj-2/index.scss
@@ -4,5 +4,8 @@
     color: var(--brand-1);
     background-color: var(--brand-3);
     border-color: var(--brand-3);
+
+    // Non-declared variable tests
+    color: var(--space-2);
   }
 }

--- a/examples/safe-parser/.vscode/settings.json
+++ b/examples/safe-parser/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
-  "cssvar.files": ["source.*"],
+  // You will have to import all CSS source files, that contains
+  // CSS variables for CSS Variable Linting to work.
+  // For e.g. If you remove `index.css` from below source files list
+  // CSS Variables defined inside `index.css` file will be considered as unknown
+  // and thus this extension will lint them as error on usage.
+  "cssvar.files": ["index.css", "source.*"],
 
   // Override default setting it to error
   // "cssvar.mode": "error"

--- a/examples/safe-parser/.vscode/settings.json
+++ b/examples/safe-parser/.vscode/settings.json
@@ -1,3 +1,15 @@
 {
-  "cssvar.files": ["source.*"]
+  "cssvar.files": ["source.*"],
+
+  // Override default setting it to error
+  // "cssvar.mode": "error"
+
+  // OR
+  "cssvar.mode": ["warn", {
+    "ignore": [
+      "^--astro-.*",
+      "ignore-.*?",
+      "--color-astro-3",
+    ]
+  }]
 }

--- a/examples/safe-parser/index.css
+++ b/examples/safe-parser/index.css
@@ -3,6 +3,7 @@
   background-color: var(--color-tsx-2);
   padding: var(--space-1);
   border-color: var(--brand-2);
-  color: var(--color-astro-1);
-  border-width: var(--space-2);
+  color: var( --color-astro-1 );
+  border-width: var(--space-1);
+  color: var(--color-astro-3);
 }

--- a/examples/safe-parser/index.css
+++ b/examples/safe-parser/index.css
@@ -15,3 +15,7 @@
   color: var(--ignore-me);
   color: var(--color-astro-4);
 }
+
+.wrapper {
+  --color-astro-4: #333;
+}

--- a/examples/safe-parser/index.css
+++ b/examples/safe-parser/index.css
@@ -5,5 +5,13 @@
   border-color: var(--brand-2);
   color: var( --color-astro-1 );
   border-width: var(--space-1);
+
+  /* Random Igore linting tests */
   color: var(--color-astro-3);
+  color: var(--astro-3);
+  color: var(--astro-ignored);
+  color: var(--do-not-ignored-this);
+  color: var(--ignore-me);
+  color: var(--ignore-me);
+  color: var(--color-astro-4);
 }

--- a/feature-contributions.md
+++ b/feature-contributions.md
@@ -216,10 +216,9 @@ This Extension supports the following properties as of now:
       E.g.<pre lang="js">["error", {
   ignore: [
     "--dynamic",
-    "--undeclared"
+    "dy[nN].*?c$"
   ]
 }]</pre>
-    <code>ignore</code> can also be a <b>regex</b> string
     </td>
     <td><pre lang="ts">string
 | [

--- a/feature-contributions.md
+++ b/feature-contributions.md
@@ -1,0 +1,272 @@
+<div align="center">
+  <img
+  src="https://user-images.githubusercontent.com/11786283/113474026-dd0dd100-948a-11eb-8140-4570d7c983d3.png"
+  height="150"
+  alt="CssVar Icon" />
+</div>
+
+
+<h1 align="center">
+  CSS Variables
+</h1>
+
+<div align="center">
+  <p align="center">
+    <i><b>Please vote/rate and star this project to show your support.</b></i>
+    ❤️
+  </p>
+
+  <a href="https://github.com/willofindie/vscode-cssvar">
+    <img src="https://img.shields.io/github/stars/willofindie/vscode-cssvar?style=social" />
+  </a>
+  &nbsp;&nbsp;
+  <img src="https://img.shields.io/badge/size-%3C%20200KB-blue?style=flat" />
+  &nbsp;&nbsp;
+  <a href="https://marketplace.visualstudio.com/items?itemName=phoenisx.cssvar">
+    <img src="https://img.shields.io/visual-studio-marketplace/i/phoenisx.cssvar?label=vsc%20installs" />
+  </a>
+  &nbsp;&nbsp;
+  <a href="https://open-vsx.org/extension/phoenisx/cssvar">
+    <img src="https://img.shields.io/open-vsx/dt/phoenisx/cssvar?color=yellowgreen&label=ovsx%20installs" />
+  </a>
+  <br />
+  <a href="https://marketplace.visualstudio.com/items?itemName=phoenisx.cssvar&ssr=false#review-details">
+    <img src="https://img.shields.io/visual-studio-marketplace/r/phoenisx.cssvar?label=vsc%20rating" />
+  </a>
+  &nbsp;&nbsp;
+  <a href="https://open-vsx.org/extension/phoenisx/cssvar/reviews">
+    <img src="https://img.shields.io/open-vsx/rating/phoenisx/cssvar?color=yellowgreen&label=ovsx%20rating" />
+  </a>
+</div>
+
+## 🛠 Supported Configs:
+
+This Extension supports the following properties as of now:
+
+<details open>
+  <summary style="font-size: 1.25rem;">Settings</summary>
+
+
+<table>
+<thead>
+  <tr align="left">
+    <th><b>Setting</b></th>
+    <th><b>Description</b></th>
+    <th><b>Type</b></th>
+    <th><b>Default</b></th>
+  </tr>
+</thead>
+<tbody>
+  <tr align="left">
+    <td><code>cssvar.files</code></td>
+    <td>
+      Relative/Absolute paths to CSS variable source files
+    </td>
+    <td><code>string[]</code></td>
+    <td><br>
+      <pre lang="js">["**/*.css"]</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td><code>cssvar.ignore</code></td>
+    <td>
+      Relative/Absolute paths to file/folder sources to be ignored
+    </td>
+    <td><code>string[]</code></td>
+    <td><br>
+      <pre lang="js">["**/node_modules/**"]</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td><code>cssvar.extensions</code></td>
+    <td>File extensions in which IntelliSense will be enabled</td>
+    <td><code>string[]</code></td>
+    <td>
+      <br>
+      <pre lang="js">[
+  "css",
+  "scss",
+  "sass",
+  "less",
+  "postcss",
+  "vue",
+  "svelte",
+  "astro",
+  "ts",
+  "tsx",
+  "js",
+  "jsx"
+]</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td>
+      <code>cssvar.themes</code>
+      <br>Helps to bucket CSS variables based on themes used in any project
+    </td>
+    <td>
+      <br>CSS Theme class names used in source files
+      <br>E.g.<pre lang="js">["dark","dim"]</pre>
+    </td>
+    <td><code>string[]</code></td>
+    <td>
+      <br>
+      <pre lang="js">[]</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td>
+      <code>cssvar.excludeThemedVariables</code>
+      <br>If <code>true</code>, hides duplicate theme variables from the list
+    </td>
+    <td>Exclude themed variables to remove unnecessary duplicates</td>
+    <td><code>boolean</code></td>
+    <td>
+      <br>
+      <pre lang="js">false</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td>
+      <code>cssvar.disableSort</code>
+      <br>Intellisense list won't be sorted
+    </td>
+    <td>Disables default sorting applied by VSCode</td>
+    <td><code>boolean</code></td>
+    <td>
+      <br>
+      <pre lang="js">false</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td><code>cssvar.enableColors</code></td>
+    <td>Enable VSCode's Color Representation feature when <code>true</code></td>
+    <td><code>boolean</code></td>
+    <td>
+      <br>
+      <pre lang="js">true</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td><code>cssvar.enableGotoDef</code></td>
+    <td>Enable VSCode's Goto Definition feature for CSS Variable</td>
+    <td><code>boolean</code></td>
+    <td>
+      <br>
+      <pre lang="js">true</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td><code>cssvar.enableHover</code></td>
+    <td>Enable VScode's Hover IntelliSense feature for CSS Variables</td>
+    <td><code>boolean</code></td>
+    <td>
+      <br>
+      <pre lang="js">true</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td>
+      <code>cssvar.postcssSyntax</code>
+      <br>Details for this can be read here: <a href="./docs/customize-extension.md">Customize Extension</a>
+    </td>
+    <td>
+      <br>Provides custom syntax parser for the mapped file extensions.
+      <br>E.g.<pre lang="js">{
+  "sugarss": ["sss"]
+}</pre>
+    </td>
+    <td><code>Record&lt;string,string[]<br>&gt;</code></td>
+    <td>
+      <br>
+      <pre lang="js">{}</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td>
+      <code>cssvar.postcssPlugins</code>
+    </td>
+    <td>
+      <br>Provide PostCSS Plugins to support custom CSS features
+      <br>E.g.<pre lang="js">["postcss-nested"]</pre>
+    </td>
+    <td><code>string[]</code></td>
+    <td>
+      <br>
+      <pre lang="js">[]</pre>
+      <br>
+    </td>
+  </tr>
+  <tr align="left">
+    <td>
+      <code>cssvar.mode</code>
+      <br>Enable/Disable CSS variable linting modes.
+    </td>
+    <td>
+      E.g.<pre lang="js">["error", {
+  ignore: [
+    "--dynamic",
+    "--undeclared"
+  ]
+}]</pre>
+    <code>ignore</code> can also be a <b>regex</b> string
+    </td>
+    <td><pre lang="ts">string
+| [
+    string,
+    {ignore: string[]}
+  ]</pre></td>
+    <td><br>
+      <pre lang="js">"off"</pre>
+      <br>
+    </td>
+  </tr>
+</tbody>
+</table>
+<br/><br/>
+
+</details>
+
+<details>
+<summary style="font-size: 1.25rem;">Supported Languages/Extensions</summary>
+
+### CSS
+Any file with extensions `.css` and `.postcss` will be treated as CSS file.
+
+### SASS
+Any file with extensiosn `.scss` and `sass` will be treated as SCSS and SASS files respectively.
+
+### LESS
+Any file with extension `.less` will be treated as LESS file.
+
+### SVELTE
+Any file with extension `.svelte` will be treated as Svelte file.
+
+### VUE
+Any file with extension `.vue` will be treated as Vue file.
+
+### ASTRO
+Any file with extension `.astro` will be treated as Astro file.
+
+### JS
+Any file with extension `.js` or `.jsx` will be treated as Javascript files.
+
+### TS
+Any file with extension `.ts` or `.tsx` will be treated as Typescript files.
+
+---
+
+To support more extension/languages where this extension can trigger
+it's IntelliSense, [please raise a request](https://github.com/willofindie/vscode-cssvar/issues/new)
+
+To enable this extension for less languages, use `cssvar.extensions` settings to override the defaults.

--- a/package.json
+++ b/package.json
@@ -336,8 +336,8 @@
 							],
 							"enumDescriptions": [
 								"Disable CSS Variable linting",
-								"Enable CSS Variable linting with `warn` specifier",
-								"Enable CSS Variable linting with `error` specifier"
+								"Enable CSS Variable linting with `warn` severity",
+								"Enable CSS Variable linting with `error` severity"
 							]
 						},
 						{
@@ -346,15 +346,13 @@
 							"properties": {
 								"ignore": {
 									"type": "array",
-									"default": [
-
-									],
+									"default": [],
 									"items": {
 										"type": "string"
 									},
 									"examples": [
-										"--variable",
-										"--(regex)"
+										["--variable"],
+										["--(regex)"]
 									],
 									"description": "CSS variable safelist for which linting will be disabled"
 								}

--- a/package.json
+++ b/package.json
@@ -1,379 +1,428 @@
 {
-  "name": "cssvar",
-  "displayName": "CSS Var Complete",
-  "keywords": [
-    "css",
-    "css3",
-    "variable",
-    "css variables",
-    "css custom properties",
-    "css var",
-    "cssvar",
-    "autocomplete",
-    "complete",
-    "intellisense",
-    "astro",
-    "vue",
-    "react",
-    "angular",
-    "javascript",
-    "typescript"
-  ],
-  "description": "Intellisense support for CSS Variables",
-  "version": "2.2.2",
-  "publisher": "phoenisx",
-  "license": "MIT",
-  "homepage": "https://github.com/willofindie/vscode-cssvar",
-  "bugs": {
-    "url": "https://github.com/willofindie/vscode-cssvar/issues"
-  },
-  "repository": {
-    "url": "https://github.com/willofindie/vscode-cssvar",
-    "type": "git"
-  },
-  "icon": "img/icon.png",
-  "engines": {
-    "vscode": "^1.53.0",
-    "node": "^12.18.3"
-  },
-  "categories": [
-    "Other"
-  ],
-  "activationEvents": [
-    "onLanguage:css",
-    "onLanguage:scss",
-    "onLanguage:sass",
-    "onLanguage:less",
-    "onLanguage:postcss",
-    "onLanguage:svelte",
-    "onLanguage:vue",
-    "onLanguage:astro",
-    "onLanguage:javascript",
-    "onLanguage:javascriptreact",
-    "onLanguage:typescript",
-    "onLanguage:typescriptreact"
-  ],
-  "main": "./out/extension.js",
-  "preview": false,
-  "contributes": {
-    "configuration": {
-      "title": "CSS Variables",
-      "properties": {
-        "cssvar.files": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "default": null,
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Relative/Absolute paths to CSS variable file sources",
-          "scope": "resource",
-          "examples": [
-            [
-              "src/**/*.css",
-              "styles/global.css"
-            ]
-          ]
-        },
-        "cssvar.ignore": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "default": null,
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Relative/Absolute paths to file/folder sources to ignore",
-          "scope": "resource",
-          "examples": [
-            [
-              "**/node_modules/**",
-              "styles/ignore.css"
-            ]
-          ]
-        },
-        "cssvar.extensions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "default": null,
-          "items": {
-            "type": "string",
-            "enum": [
-              "css",
-              "scss",
-              "sass",
-              "less",
-              "postcss",
-              "vue",
-              "svelte",
-              "astro",
-              "ts",
-              "tsx",
-              "jsx",
-              "js"
-            ]
-          },
-          "markdownDescription": "File extensions for which IntelliSense will be enabled",
-          "scope": "resource",
-          "examples": [
-            [
-              "css",
-              "scss",
-              "tsx",
-              "jsx"
-            ]
-          ]
-        },
-        "cssvar.themes": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "default": null,
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "CSS Theme classnames used in source files",
-          "scope": "resource",
-          "examples": [
-            [
-              "dark",
-              "dim"
-            ]
-          ]
-        },
-        "cssvar.excludeThemedVariables": {
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "default": null,
-          "markdownDescription": "Exclude themed variables to remove unnecessary duplicates",
-          "scope": "resource",
-          "examples": [
-            true,
-            false
-          ]
-        },
-        "cssvar.disableSort": {
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "default": null,
-          "markdownDescription": "Disables default sorting applied by VSCode",
-          "scope": "resource",
-          "examples": [
-            true,
-            false
-          ]
-        },
-        "cssvar.enableColors": {
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "default": null,
-          "markdownDescription": "Enable VScode's Color Representation feature when true",
-          "scope": "window",
-          "examples": [
-            true,
-            false
-          ]
-        },
-        "cssvar.enableGotoDef": {
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "default": null,
-          "markdownDescription": "Enable VScode's Goto Definition feature for CSS Variables",
-          "scope": "window",
-          "examples": [
-            true,
-            false
-          ]
-        },
-        "cssvar.enableHover": {
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "default": null,
-          "markdownDescription": "Enable VScode's Hover IntelliSense feature for CSS Variables",
-          "scope": "window",
-          "examples": [
-            true,
-            false
-          ]
-        },
-        "cssvar.postcssPlugins": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "default": null,
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Provide __PostCSS__ plugins to support custom CSS features. List of __PostCSS__ plugin names can be found in [PostCSS Doc](https://github.com/postcss/postcss#plugins)",
-          "scope": "resource",
-          "examples": [
-            [
-              "postcss-nested",
-              "webp-in-css"
-            ]
-          ]
-        },
-        "cssvar.postcssSyntax": {
-          "type": "object",
-          "default": {},
-          "properties": {
-            "postcss-sass": {
-              "type": "array",
-              "description": "Sass (.sass) source file extensions to parse",
-              "default": [
-                "sass"
-              ],
-              "examples": [
-                [
-                  "sass"
-                ]
-              ]
-            },
-            "postcss-html": {
-              "type": "array",
-              "description": "HTML (.html) source file extensions to parse",
-              "default": [
-                "html"
-              ],
-              "examples": [
-                [
-                  "html",
-                  "ejs"
-                ]
-              ]
-            },
-            "sugarss": {
-              "type": "array",
-              "description": "SugarSS (.sss) source file extensions to parse",
-              "default": [
-                "sss"
-              ],
-              "examples": [
-                [
-                  "sss"
-                ]
-              ]
-            },
-            "postcss-styl": {
-              "type": "array",
-              "description": "Stylus (.styl) source file extensions to parse. Repo: https://github.com/stylus/postcss-styl",
-              "default": [
-                "styl"
-              ],
-              "examples": [
-                [
-                  "styl"
-                ]
-              ]
-            },
-            "postcss-syntax": {
-              "type": "array",
-              "description": "To parse template literals in JS/TS source files. Details: https://github.com/willofindie/vscode-cssvar/tree/main/docs/customize-extension.md",
-              "default": [],
-              "examples": [
-                [
-                  "js",
-                  "ts",
-                  "sass"
-                ]
-              ]
-            },
-            "postcss-lit": {
-              "type": "array",
-              "description": "To parse Lit templates in JS/TS source files. Repo: https://github.com/43081j/postcss-lit",
-              "default": [
-                "ts"
-              ],
-              "examples": [
-                [
-                  "js",
-                  "ts"
-                ]
-              ]
-            }
-          },
-          "additionalProperties": true,
-          "markdownDescription": "Add support for custom CSS syntaxes like `sass`, `styl` and more. Details on Customization can be [read here](https://github.com/willofindie/vscode-cssvar/tree/main/docs/customize-extension.md)",
-          "scope": "resource"
-        }
-      }
-    }
-  },
-  "scripts": {
-    "postinstall": "husky install",
-    "pub": "src/scripts/publish.js",
-    "prebuild": "rimraf out",
-    "build": "cross-env NODE_ENV=production rollup -c --environment INCLUDE_DEPS,BUILD,NODE_ENV:production",
-    "watch": "rollup -c -m -w",
-    "lint": "eslint src --ext ts",
-    "lint:fix": "eslint src --ext ts --fix",
-    "test": "concurrently \"tsc --project ./tsconfig.json --noEmit\" \"jest\""
-  },
-  "devDependencies": {
-    "@babel/core": "^7.17.8",
-    "@babel/preset-env": "^7.16.11",
-    "@babel/preset-typescript": "^7.16.7",
-    "@rollup/plugin-commonjs": "^18.1.0",
-    "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^11.2.1",
-    "@rollup/plugin-replace": "^4.0.0",
-    "@types/css": "^0.0.31",
-    "@types/glob": "^7.2.0",
-    "@types/jest": "^26.0.24",
-    "@types/lodash": "^4.14.180",
-    "@types/node": "12.12.6",
-    "@types/postcss-less": "^4.0.2",
-    "@types/postcss-safe-parser": "^5.0.1",
-    "@types/vscode": "1.53.0",
-    "@typescript-eslint/eslint-plugin": "^5.17.0",
-    "@typescript-eslint/parser": "^5.17.0",
-    "babel-jest": "^26.6.3",
-    "concurrently": "^7.3.0",
-    "cross-env": "^7.0.3",
-    "dayjs": "^1.11.5",
-    "dotenv": "^16.0.2",
-    "esbuild": "^0.14.49",
-    "eslint": "^7.32.0",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-jest": "^24.7.0",
-    "eslint-plugin-prettier": "^3.4.1",
-    "husky": "^5.2.0",
-    "jest": "^26.6.3",
-    "lint-staged": "^10.5.4",
-    "lodash": "^4.17.21",
-    "prettier": "^2.6.1",
-    "rimraf": "^3.0.2",
-    "rollup": "^2.70.1",
-    "rollup-plugin-esbuild": "^4.9.1",
-    "typescript": "^4.6.3",
-    "yargs": "^17.5.1"
-  },
-  "dependencies": {
-    "culori": "^2.0.3",
-    "fast-glob": "^3.2.11",
-    "postcss": "^8.4.12",
-    "postcss-less": "^6.0.0"
-  },
-  "lint-staged": {
-    "*.{ts,tsx}": [
-      "npm run lint:fix"
-    ]
-  }
+	"name": "cssvar",
+	"displayName": "CSS Var Complete",
+	"keywords": [
+		"css",
+		"css3",
+		"variable",
+		"css variables",
+		"css custom properties",
+		"css var",
+		"cssvar",
+		"autocomplete",
+		"complete",
+		"intellisense",
+		"astro",
+		"vue",
+		"react",
+		"angular",
+		"javascript",
+		"typescript"
+	],
+	"description": "Intellisense support for CSS Variables",
+	"version": "2.2.2",
+	"publisher": "phoenisx",
+	"license": "MIT",
+	"homepage": "https://github.com/willofindie/vscode-cssvar",
+	"bugs": {
+		"url": "https://github.com/willofindie/vscode-cssvar/issues"
+	},
+	"repository": {
+		"url": "https://github.com/willofindie/vscode-cssvar",
+		"type": "git"
+	},
+	"icon": "img/icon.png",
+	"engines": {
+		"vscode": "^1.53.0",
+		"node": "^12.18.3"
+	},
+	"categories": [
+		"Other"
+	],
+	"activationEvents": [
+		"onLanguage:css",
+		"onLanguage:scss",
+		"onLanguage:sass",
+		"onLanguage:less",
+		"onLanguage:postcss",
+		"onLanguage:svelte",
+		"onLanguage:vue",
+		"onLanguage:astro",
+		"onLanguage:javascript",
+		"onLanguage:javascriptreact",
+		"onLanguage:typescript",
+		"onLanguage:typescriptreact"
+	],
+	"main": "./out/extension.js",
+	"preview": false,
+	"contributes": {
+		"configuration": {
+			"title": "CSS Variables",
+			"properties": {
+				"cssvar.files": {
+					"type": [
+						"array",
+						"null"
+					],
+					"default": null,
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "Relative/Absolute paths to CSS variable file sources",
+					"scope": "resource",
+					"examples": [
+						[
+							"src/**/*.css",
+							"styles/global.css"
+						]
+					]
+				},
+				"cssvar.ignore": {
+					"type": [
+						"array",
+						"null"
+					],
+					"default": null,
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "Relative/Absolute paths to file/folder sources to ignore",
+					"scope": "resource",
+					"examples": [
+						[
+							"**/node_modules/**",
+							"styles/ignore.css"
+						]
+					]
+				},
+				"cssvar.extensions": {
+					"type": [
+						"array",
+						"null"
+					],
+					"default": null,
+					"items": {
+						"type": "string",
+						"enum": [
+							"css",
+							"scss",
+							"sass",
+							"less",
+							"postcss",
+							"vue",
+							"svelte",
+							"astro",
+							"ts",
+							"tsx",
+							"jsx",
+							"js"
+						]
+					},
+					"markdownDescription": "File extensions for which IntelliSense will be enabled",
+					"scope": "resource",
+					"examples": [
+						[
+							"css",
+							"scss",
+							"tsx",
+							"jsx"
+						]
+					]
+				},
+				"cssvar.themes": {
+					"type": [
+						"array",
+						"null"
+					],
+					"default": null,
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "CSS Theme classnames used in source files",
+					"scope": "resource",
+					"examples": [
+						[
+							"dark",
+							"dim"
+						]
+					]
+				},
+				"cssvar.excludeThemedVariables": {
+					"type": [
+						"boolean",
+						"null"
+					],
+					"default": null,
+					"markdownDescription": "Exclude themed variables to remove unnecessary duplicates",
+					"scope": "resource",
+					"examples": [
+						true,
+						false
+					]
+				},
+				"cssvar.disableSort": {
+					"type": [
+						"boolean",
+						"null"
+					],
+					"default": null,
+					"markdownDescription": "Disables default sorting applied by VSCode",
+					"scope": "resource",
+					"examples": [
+						true,
+						false
+					]
+				},
+				"cssvar.enableColors": {
+					"type": [
+						"boolean",
+						"null"
+					],
+					"default": null,
+					"markdownDescription": "Enable VScode's Color Representation feature when true",
+					"scope": "window",
+					"examples": [
+						true,
+						false
+					]
+				},
+				"cssvar.enableGotoDef": {
+					"type": [
+						"boolean",
+						"null"
+					],
+					"default": null,
+					"markdownDescription": "Enable VScode's Goto Definition feature for CSS Variables",
+					"scope": "window",
+					"examples": [
+						true,
+						false
+					]
+				},
+				"cssvar.enableHover": {
+					"type": [
+						"boolean",
+						"null"
+					],
+					"default": null,
+					"markdownDescription": "Enable VScode's Hover IntelliSense feature for CSS Variables",
+					"scope": "window",
+					"examples": [
+						true,
+						false
+					]
+				},
+				"cssvar.postcssPlugins": {
+					"type": [
+						"array",
+						"null"
+					],
+					"default": null,
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "Provide __PostCSS__ plugins to support custom CSS features. List of __PostCSS__ plugin names can be found in [PostCSS Doc](https://github.com/postcss/postcss#plugins)",
+					"scope": "resource",
+					"examples": [
+						[
+							"postcss-nested",
+							"webp-in-css"
+						]
+					]
+				},
+				"cssvar.postcssSyntax": {
+					"type": "object",
+					"default": {
+
+					},
+					"properties": {
+						"postcss-sass": {
+							"type": "array",
+							"description": "Sass (.sass) source file extensions to parse",
+							"default": [
+								"sass"
+							],
+							"examples": [
+								[
+									"sass"
+								]
+							]
+						},
+						"postcss-html": {
+							"type": "array",
+							"description": "HTML (.html) source file extensions to parse",
+							"default": [
+								"html"
+							],
+							"examples": [
+								[
+									"html",
+									"ejs"
+								]
+							]
+						},
+						"sugarss": {
+							"type": "array",
+							"description": "SugarSS (.sss) source file extensions to parse",
+							"default": [
+								"sss"
+							],
+							"examples": [
+								[
+									"sss"
+								]
+							]
+						},
+						"postcss-styl": {
+							"type": "array",
+							"description": "Stylus (.styl) source file extensions to parse. Repo: https://github.com/stylus/postcss-styl",
+							"default": [
+								"styl"
+							],
+							"examples": [
+								[
+									"styl"
+								]
+							]
+						},
+						"postcss-syntax": {
+							"type": "array",
+							"description": "To parse template literals in JS/TS source files. Details: https://github.com/willofindie/vscode-cssvar/tree/main/docs/customize-extension.md",
+							"default": [
+
+							],
+							"examples": [
+								[
+									"js",
+									"ts",
+									"sass"
+								]
+							]
+						},
+						"postcss-lit": {
+							"type": "array",
+							"description": "To parse Lit templates in JS/TS source files. Repo: https://github.com/43081j/postcss-lit",
+							"default": [
+								"ts"
+							],
+							"examples": [
+								[
+									"js",
+									"ts"
+								]
+							]
+						}
+					},
+					"additionalProperties": true,
+					"markdownDescription": "Add support for custom CSS syntaxes like `sass`, `styl` and more. Details on Customization can be [read here](https://github.com/willofindie/vscode-cssvar/tree/main/docs/customize-extension.md)",
+					"scope": "resource"
+				},
+				"cssvar.mode": {
+					"scope": "resource",
+					"type": [
+						"array",
+						"string"
+					],
+					"default": "off",
+					"markdownDescription": "Enable/Disable CSS variable linting modes.",
+					"items": [
+						{
+							"type": "string",
+							"default": "off",
+							"enum": [
+								"off",
+								"warn",
+								"error"
+							],
+							"enumDescriptions": [
+								"Disable CSS Variable linting",
+								"Enable CSS Variable linting with `warn` specifier",
+								"Enable CSS Variable linting with `error` specifier"
+							]
+						},
+						{
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"ignore": {
+									"type": "array",
+									"default": [
+
+									],
+									"items": {
+										"type": "string"
+									},
+									"examples": [
+										"--variable",
+										"--(regex)"
+									],
+									"description": "CSS variable safelist for which linting will be disabled"
+								}
+							}
+						}
+					]
+				}
+			}
+		}
+	},
+	"scripts": {
+		"postinstall": "husky install",
+		"pub": "src/scripts/publish.js",
+		"prebuild": "rimraf out",
+		"build": "cross-env NODE_ENV=production rollup -c --environment INCLUDE_DEPS,BUILD,NODE_ENV:production",
+		"watch": "rollup -c -m -w",
+		"lint": "eslint src --ext ts",
+		"lint:fix": "eslint src --ext ts --fix",
+		"test": "concurrently \"tsc --project ./tsconfig.json --noEmit\" \"jest\""
+	},
+	"devDependencies": {
+		"@babel/core": "^7.17.8",
+		"@babel/preset-env": "^7.16.11",
+		"@babel/preset-typescript": "^7.16.7",
+		"@rollup/plugin-commonjs": "^18.1.0",
+		"@rollup/plugin-json": "^4.1.0",
+		"@rollup/plugin-node-resolve": "^11.2.1",
+		"@rollup/plugin-replace": "^4.0.0",
+		"@types/css": "^0.0.31",
+		"@types/glob": "^7.2.0",
+		"@types/jest": "^26.0.24",
+		"@types/lodash": "^4.14.180",
+		"@types/node": "12.12.6",
+		"@types/postcss-less": "^4.0.2",
+		"@types/postcss-safe-parser": "^5.0.1",
+		"@types/vscode": "1.53.0",
+		"@typescript-eslint/eslint-plugin": "^5.17.0",
+		"@typescript-eslint/parser": "^5.17.0",
+		"babel-jest": "^26.6.3",
+		"concurrently": "^7.3.0",
+		"cross-env": "^7.0.3",
+		"dayjs": "^1.11.5",
+		"dotenv": "^16.0.2",
+		"esbuild": "^0.14.49",
+		"eslint": "^7.32.0",
+		"eslint-config-prettier": "^8.5.0",
+		"eslint-plugin-jest": "^24.7.0",
+		"eslint-plugin-prettier": "^3.4.1",
+		"husky": "^5.2.0",
+		"jest": "^26.6.3",
+		"lint-staged": "^10.5.4",
+		"lodash": "^4.17.21",
+		"prettier": "^2.6.1",
+		"rimraf": "^3.0.2",
+		"rollup": "^2.70.1",
+		"rollup-plugin-esbuild": "^4.9.1",
+		"typescript": "^4.6.3",
+		"yargs": "^17.5.1"
+	},
+	"dependencies": {
+		"culori": "^2.0.3",
+		"fast-glob": "^3.2.11",
+		"postcss": "^8.4.12",
+		"postcss-less": "^6.0.0"
+	},
+	"lint-staged": {
+		"*.{ts,tsx}": [
+			"npm run lint:fix"
+		]
+	}
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -254,6 +254,8 @@ export const SCSS_COLOR_INTERPOLATION = /^#{\s*?(\$\S+?)\s*}$/i;
 
 export const CSS_VAR_FUNCTION_NOTATION = /^var\s*\((?<args>.*?)\)$/i;
 
+export const PATTERN_ALL_VARIABLE_USAGES = /var\s*\((.*?)\)/g;
+
 export const SUPPORTED_CSS_RULE_TYPES = ["rule", "decl", "atrule"] as const;
 export const SUPPORTED_IMPORT_NAMES = new Set(["import", "use", "forward"]);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -133,7 +133,7 @@ export type CacheType = {
   cssVarDefinitionsMap: {
     [activeRootpath: string]: { [varName: string]: Location[] };
   };
-  cssVarErrors: { [activeRootpath: string]: number };
+  cssVarCount: { [activeRootpath: string]: number };
   // Following propety should always point to a local file path
   filesToWatch: { [activeRootpath: string]: Set<string> };
   fileMetas: {
@@ -151,7 +151,7 @@ export const CACHE: CacheType = {
   cssVars: {},
   cssVarsMap: {},
   cssVarDefinitionsMap: {},
-  cssVarErrors: {},
+  cssVarCount: {},
   filesToWatch: {},
   fileMetas: {},
   config: {}, // Points to active config.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,6 +53,8 @@ export type CSSVarLocation = {
   isRemote: boolean;
 };
 
+export type LintingSeverity = "off" | "warn" | "error";
+
 /**
  * Since the inmem config this project maintains is completely diffent than
  * what user-facing setting types are, it was necessary to separate these two
@@ -64,6 +66,7 @@ export interface Config {
   ignore: string[];
   extensions: SupportedExtensionNames[];
   themes: string[];
+  mode: [LintingSeverity, { ignore: string[] }];
   postcssPlugins: string[];
   postcssSyntax: Record<string, string>;
   excludeThemedVariables: boolean;
@@ -73,8 +76,9 @@ export interface Config {
   enableHover: boolean;
 }
 
-export type WorkspaceConfig = Omit<Config, "files"> & {
+export type WorkspaceConfig = Omit<Config, "files" | "mode"> & {
   files: string[];
+  mode: LintingSeverity | [LintingSeverity, { ignore: string[] }];
 };
 
 /**
@@ -86,6 +90,7 @@ export const DEFAULT_CONFIG: WorkspaceConfig = {
   files: ["**/*.css"],
   ignore: ["**/node_modules/**"],
   extensions: [...SUPPORTED_LANGUAGE_IDS],
+  mode: "off",
   themes: [],
   postcssPlugins: [],
   postcssSyntax: {},

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -128,6 +128,7 @@ export type CacheType = {
   cssVarDefinitionsMap: {
     [activeRootpath: string]: { [varName: string]: Location[] };
   };
+  cssVarErrors: { [activeRootpath: string]: number };
   // Following propety should always point to a local file path
   filesToWatch: { [activeRootpath: string]: Set<string> };
   fileMetas: {
@@ -145,6 +146,7 @@ export const CACHE: CacheType = {
   cssVars: {},
   cssVarsMap: {},
   cssVarDefinitionsMap: {},
+  cssVarErrors: {},
   filesToWatch: {},
   fileMetas: {},
   config: {}, // Points to active config.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
       );
     }
 
+    // Sequence of subscriptions matter.
+    context.subscriptions.push(
+      window.onDidChangeActiveTextEditor(updateStatus)
+    );
+
     const completionDisposable = languages.registerCompletionItemProvider(
       config[CACHE.activeRootPath].extensions || DEFAULT_CONFIG.extensions,
       new CssCompletionProvider(),
@@ -107,10 +112,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
       }
     }
     //#endregion
-
-    context.subscriptions.push(
-      window.onDidChangeActiveTextEditor(updateStatus)
-    );
   } catch (err) {
     if (err instanceof Error) {
       window.showErrorMessage(err.message);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,13 +9,14 @@ import {
 } from "vscode";
 import { CssColorProvider } from "./providers/color-provider";
 import { CssCompletionProvider } from "./providers/completion-provider";
-import { CACHE, DEFAULT_CONFIG } from "./constants";
+import { CACHE, DEFAULT_CONFIG, EXTENSION_NAME } from "./constants";
 import { CssDefinitionProvider } from "./providers/definition-provider";
 import { LOGGER } from "./logger";
 import { setup } from "./main";
 import { parseFiles } from "./parser";
 import { isObjectProperty } from "./utils";
 import { CssHoverProvider } from "./providers/hover-provider";
+import { subscribeToDocumentChanges } from "./providers/diagnostics";
 
 const watchers: FileSystemWatcher[] = [];
 
@@ -69,6 +70,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
       );
       context.subscriptions.push(definitionDisposable);
     }
+
+    const cssvarDiagnostics =
+      languages.createDiagnosticCollection(EXTENSION_NAME);
+    context.subscriptions.push(cssvarDiagnostics);
+    subscribeToDocumentChanges(context, cssvarDiagnostics);
 
     //#region File Watcher
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,6 +141,23 @@ export async function setup(): Promise<{
             }
             break;
           }
+          case "mode": {
+            const mode = _config.get<WorkspaceConfig["mode"]>(key);
+            let _mode: Config["mode"];
+            if (typeof mode === "string") {
+              _mode = [mode, { ignore: [] }];
+            } else if (
+              Array.isArray(mode) &&
+              mode.length > 0 &&
+              mode.length < 3
+            ) {
+              _mode = [mode[0], mode[1] || { ignore: [] }];
+            } else {
+              _mode = ["off", { ignore: [] }];
+            }
+            config[fsPathKey][key] = _mode;
+            break;
+          }
           default: {
             const value = getConfigValue(_config, key);
             config[fsPathKey][key] = value as any;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -351,9 +351,9 @@ const parseFilesForSingleFolder = async function (
         newVars = await parseFile(location, config, rootPath);
       } catch (e) {
         errorPaths.push(location.local);
-        // Log errors for actual URL paths, and not the cached filepaths.
         LOGGER.warn(
-          `Failed to Parse file (${path}): `,
+          `Failed to Parse file (${location.local}): `,
+          " :: what :: ",
           getCSSErrorMsg(location.remote || location.local, e as any)
         );
       }
@@ -371,6 +371,7 @@ const parseFilesForSingleFolder = async function (
         cssVars = await executeParsing(cssvarLocation);
       }
     } else {
+      // Remote files should always be parsed and cached
       cssVars = await executeParsing(cssvarLocation);
     }
 
@@ -396,6 +397,7 @@ const parseFilesForSingleFolder = async function (
   if (CACHE.cssVars[rootPath] !== cssVars) {
     try {
       const [vars, cssVarsMap] = await populateValue(cssVars);
+      CACHE.cssVarErrors[rootPath] = vars.length;
       CACHE.cssVarDefinitionsMap[rootPath] = vars.reduce((defs, cssVar) => {
         if (!cssVar.location) {
           return defs;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -397,7 +397,7 @@ const parseFilesForSingleFolder = async function (
   if (CACHE.cssVars[rootPath] !== cssVars) {
     try {
       const [vars, cssVarsMap] = await populateValue(cssVars);
-      CACHE.cssVarErrors[rootPath] = vars.length;
+      CACHE.cssVarCount[rootPath] = vars.length;
       CACHE.cssVarDefinitionsMap[rootPath] = vars.reduce((defs, cssVar) => {
         if (!cssVar.location) {
           return defs;

--- a/src/providers/definition-provider.ts
+++ b/src/providers/definition-provider.ts
@@ -6,7 +6,7 @@ import {
   Range,
   TextDocument,
 } from "vscode";
-import { CACHE } from "../constants";
+import { CACHE, PATTERN_ALL_VARIABLE_USAGES } from "../constants";
 import { getActiveRootPath } from "../utils";
 
 export class CssDefinitionProvider implements DefinitionProvider {
@@ -21,7 +21,7 @@ export class CssDefinitionProvider implements DefinitionProvider {
       )
     );
 
-    const matches = text.matchAll(/var\s*\((.*?)\)/g);
+    const matches = text.matchAll(PATTERN_ALL_VARIABLE_USAGES);
     let exactMatch = "";
     for (const match of matches) {
       const start = match.index

--- a/src/providers/definition-provider.ts
+++ b/src/providers/definition-provider.ts
@@ -29,7 +29,7 @@ export class CssDefinitionProvider implements DefinitionProvider {
         : 0;
       const end = start + match[1].length;
       if (position.character >= start && position.character <= end) {
-        exactMatch = match[1];
+        exactMatch = match[1].trim();
         break;
       }
     }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -1,0 +1,96 @@
+import {
+  Diagnostic,
+  DiagnosticCollection,
+  DiagnosticSeverity,
+  ExtensionContext,
+  Range,
+  TextDocument,
+  window,
+  workspace,
+} from "vscode";
+import {
+  CACHE,
+  EXTENSION_NAME,
+  PATTERN_ALL_VARIABLE_USAGES,
+} from "../constants";
+
+function createDiagnostic(
+  match: RegExpMatchArray,
+  lineIndex: number
+): Diagnostic | null {
+  const variableName = match[1].trim();
+  if (CACHE.cssVarsMap[CACHE.activeRootPath][variableName]) {
+    return null;
+  }
+  const start = match.index
+    ? match.index + (match[0].length - match[1].length - 1)
+    : 0;
+  const end = start + match[1].length;
+  const range = new Range(lineIndex, start, lineIndex, end);
+
+  const diagnostic = new Diagnostic(
+    range,
+    `Cannot find cssvar ${variableName}.`,
+    DiagnosticSeverity.Error
+  );
+  diagnostic.source = `(${EXTENSION_NAME})`;
+
+  // Following can be used to enhance diagnostics using codeactions
+  // to modify code if a variable is not present, like adding a variable.
+  // diagnostic.code = `${EXTENSION_NAME}_mention`;
+  return diagnostic;
+}
+
+/**
+ * Analyzes the text document for css variables that
+ * aren't defined in the source CSS files.
+ * @param doc text document to analyze
+ * @param cssvarDiagnostics diagnostic collection
+ */
+export function refreshDiagnostics(
+  doc: TextDocument,
+  cssvarDiagnostics: DiagnosticCollection
+): void {
+  const diagnostics: Diagnostic[] = [];
+
+  for (let lineIndex = 0; lineIndex < doc.lineCount; lineIndex++) {
+    const lineOfText = doc.lineAt(lineIndex);
+    const allMatchesInLine = lineOfText.text.matchAll(
+      PATTERN_ALL_VARIABLE_USAGES
+    );
+    for (const match of allMatchesInLine) {
+      const diagnostic = createDiagnostic(match, lineIndex);
+      if (diagnostic) {
+        diagnostics.push(diagnostic);
+      }
+    }
+  }
+
+  cssvarDiagnostics.set(doc.uri, diagnostics);
+}
+
+export function subscribeToDocumentChanges(
+  context: ExtensionContext,
+  cssvarDiagnostics: DiagnosticCollection
+): void {
+  if (window.activeTextEditor) {
+    refreshDiagnostics(window.activeTextEditor.document, cssvarDiagnostics);
+  }
+  context.subscriptions.push(
+    window.onDidChangeActiveTextEditor(editor => {
+      if (editor) {
+        refreshDiagnostics(editor.document, cssvarDiagnostics);
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    workspace.onDidChangeTextDocument(e =>
+      refreshDiagnostics(e.document, cssvarDiagnostics)
+    )
+  );
+
+  context.subscriptions.push(
+    workspace.onDidCloseTextDocument(doc => cssvarDiagnostics.delete(doc.uri))
+  );
+}

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -52,6 +52,11 @@ export function refreshDiagnostics(
   cssvarDiagnostics: DiagnosticCollection
 ): void {
   const diagnostics: Diagnostic[] = [];
+  if (CACHE.cssVarErrors[CACHE.activeRootPath] === 0) {
+    // This can happen if the extension fails to parse everything
+    // In which case we do not want to show any diagnostic errors/warns
+    return;
+  }
 
   for (let lineIndex = 0; lineIndex < doc.lineCount; lineIndex++) {
     const lineOfText = doc.lineAt(lineIndex);

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -37,6 +37,7 @@ function createDiagnostic(
   ) {
     return null;
   }
+
   const start = match.index
     ? match.index + (match[0].length - match[1].length - 1)
     : 0;
@@ -67,7 +68,7 @@ export function refreshDiagnostics(
   cssvarDiagnostics: DiagnosticCollection
 ): void {
   if (
-    CACHE.cssVarErrors[CACHE.activeRootPath] === 0 ||
+    CACHE.cssVarCount[CACHE.activeRootPath] === 0 ||
     CACHE.config[CACHE.activeRootPath].mode[0] === "off"
   ) {
     // This can happen if the extension fails to parse everything

--- a/src/providers/hover-provider.ts
+++ b/src/providers/hover-provider.ts
@@ -50,7 +50,7 @@ export class CssHoverProvider implements HoverProvider {
       const end = start + match[1].length;
       if (position.character >= start && position.character <= end) {
         hoverDetails = {
-          name: match[1],
+          name: match[1].trim(),
           range: new Range(
             range.start.translate({ characterDelta: start }),
             range.start.translate({ characterDelta: end })

--- a/src/test/definition-provider.test.ts
+++ b/src/test/definition-provider.test.ts
@@ -1,0 +1,94 @@
+import { Location, Position, Range, TextDocument, Uri } from "vscode";
+import { CACHE } from "../constants";
+import { getActiveRootPath } from "../utils";
+import { CssDefinitionProvider } from "../providers/definition-provider";
+
+jest.mock("../constants", () => {
+  const DEFAULT_ROOT_FOLDER = "test";
+  const CONSTANTS = jest.requireActual("../constants");
+  const VARIABLES_FILE = "path";
+
+  return {
+    __esModule: true,
+    ...CONSTANTS,
+    CACHE: {
+      ...CONSTANTS.CACHE,
+      activeRootPath: DEFAULT_ROOT_FOLDER,
+      config: {
+        [DEFAULT_ROOT_FOLDER]: {
+          ...CONSTANTS.DEFAULT_CONFIG,
+          files: [VARIABLES_FILE],
+        },
+      },
+    },
+  };
+});
+
+jest.mock("../main", () => {
+  return {
+    __esModule: true,
+    setup: jest.fn().mockResolvedValue({}),
+  };
+});
+jest.mock("../utils", () => {
+  const DEFAULT_ROOT_FOLDER = "test";
+  return {
+    __esModule: true,
+    getActiveRootPath: jest.fn().mockReturnValue(DEFAULT_ROOT_FOLDER),
+  };
+});
+
+let defProvider: CssDefinitionProvider | null;
+
+class TextDocumentStub {
+  private document: string;
+
+  constructor(doc: string) {
+    this.document = doc;
+  }
+  getText = jest.fn().mockImplementation(() => this.document);
+}
+
+beforeAll(() => {
+  defProvider = new CssDefinitionProvider();
+});
+
+afterAll(() => {
+  defProvider = null;
+});
+
+test("Definition Provider to work with variables present", async () => {
+  CACHE.cssVarDefinitionsMap = {
+    [CACHE.activeRootPath]: {
+      "--color-red-300": [new Location(
+        {
+          path: "/foo/bar",
+        } as Uri,
+        new Range(new Position(0, 3), new Position(0, 18))
+      )]
+    }
+  }
+  const document = new TextDocumentStub(
+    "color: var(--color-red-300)"
+  ) as unknown as TextDocument;
+  const def = await defProvider?.provideDefinition(
+    document,
+    new Position(0, 14)
+  ) as Location[];
+
+  expect(def.length).toBeGreaterThan(0);
+  expect(def[0].uri).toMatchObject({ path: "/foo/bar" });
+});
+
+test("Definition Provider to work w/ var() function with spaces", async () => {
+  const document = new TextDocumentStub(
+    "color: var( --color-red-300 )"
+  ) as unknown as TextDocument;
+  const def = await defProvider?.provideDefinition(
+    document,
+    new Position(0, 14)
+  ) as Location[];
+
+  expect(def.length).toBeGreaterThan(0);
+  expect(def[0].uri).toMatchObject({ path: "/foo/bar" });
+});

--- a/src/test/definition-provider.test.ts
+++ b/src/test/definition-provider.test.ts
@@ -2,6 +2,7 @@ import { Location, Position, Range, TextDocument, Uri } from "vscode";
 import { CACHE } from "../constants";
 import { getActiveRootPath } from "../utils";
 import { CssDefinitionProvider } from "../providers/definition-provider";
+import { TextDocumentStub } from "./test-utilities";
 
 jest.mock("../constants", () => {
   const DEFAULT_ROOT_FOLDER = "test";
@@ -39,15 +40,6 @@ jest.mock("../utils", () => {
 });
 
 let defProvider: CssDefinitionProvider | null;
-
-class TextDocumentStub {
-  private document: string;
-
-  constructor(doc: string) {
-    this.document = doc;
-  }
-  getText = jest.fn().mockImplementation(() => this.document);
-}
 
 beforeAll(() => {
   defProvider = new CssDefinitionProvider();

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -45,7 +45,7 @@ const runActivate = async (line: string, id: SupportedLanguageIds) => {
     ) => Promise<any[]>;
   }[] = [];
   await activate({ subscriptions } as unknown as ExtensionContext);
-  return await subscriptions[0].provideCompletionItems(
+  return await subscriptions[1].provideCompletionItems(
     { getText: () => line, languageId: id },
     new Position(0, line.length)
   );

--- a/src/test/main.test.ts
+++ b/src/test/main.test.ts
@@ -31,6 +31,7 @@ describe("Test Extension Main", () => {
           remote: "",
           isRemote: false,
         }],
+        mode: ["off", { ignore: [] }],
         disableSort: false,
       }
       const cssVars: CSSVarRecord = {
@@ -72,6 +73,7 @@ describe("Test Extension Main", () => {
           remote: "",
           isRemote: false,
         }],
+        mode: ["off", { ignore: [] }],
         disableSort: true,
       }
       const cssVars: CSSVarRecord = {
@@ -112,6 +114,7 @@ describe("Test Extension Main", () => {
       const config: Config = {
         ...DEFAULT_CONFIG,
         files: [getLocalCSSVarLocation("")],
+        mode: ["off", { ignore: [] }],
         disableSort: true,
       }
       const cssVars1: CSSVarRecord = Array(11)

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -37,6 +37,7 @@ const EXTENSION_CONFIG: ConfigRecord = {
   [CACHE.activeRootPath]: {
     ...DEFAULT_CONFIG,
     files: [getLocalCSSVarLocation(DUMMY_FILE)],
+    mode: ["off", { ignore: [] }],
   },
 };
 
@@ -255,11 +256,13 @@ describe("Multi Root", () => {
         // This config will test SCSS files
         ...DEFAULT_CONFIG,
         files: [getLocalCSSVarLocation(IMPORT_SCSS_FILE)],
+        mode: ["off", { ignore: [] }],
       },
       [rootPath2]: {
         // This config will test SCSS files
         ...DEFAULT_CONFIG,
         files: [getLocalCSSVarLocation(RENAMED_FILE)],
+        mode: ["off", { ignore: [] }],
       },
     };
     CACHE.config = config;

--- a/src/test/pre-processors/template-literals.test.ts
+++ b/src/test/pre-processors/template-literals.test.ts
@@ -26,6 +26,7 @@ const MOCK_CONFIG: ConfigRecord = {
   [CACHE.activeRootPath]: {
     ...DEFAULT_CONFIG,
     files: [getLocalCSSVarLocation(JSX_FILE_PATH)],
+    mode: ["off", { ignore: [] }],
   },
 };
 

--- a/src/test/providers/diagnostics.test.ts
+++ b/src/test/providers/diagnostics.test.ts
@@ -1,0 +1,131 @@
+import { DiagnosticCollection, TextDocument } from "vscode";
+import { CACHE, DEFAULT_CONFIG } from "../../constants";
+import { CSSVarDeclarations } from "../../main";
+import { refreshDiagnostics } from "../../providers/diagnostics";
+import { TextDocumentStub, DiagnosticCollectionStub } from "../test-utilities";
+
+type ICache = typeof CACHE;
+
+jest.mock("../../constants", () => {
+  const DEFAULT_ROOT_FOLDER = "test";
+  const CONSTANTS = jest.requireActual("../../constants");
+  const VARIABLES_FILE = "path";
+
+  return {
+    __esModule: true,
+    ...CONSTANTS,
+    CACHE: {
+      ...CONSTANTS.CACHE,
+      activeRootPath: DEFAULT_ROOT_FOLDER,
+      cssVarsMap: {
+        [DEFAULT_ROOT_FOLDER]: {},
+      },
+      config: {
+        [DEFAULT_ROOT_FOLDER]: {
+          ...CONSTANTS.DEFAULT_CONFIG,
+          files: [
+            {
+              local: VARIABLES_FILE,
+              remote: "",
+              isRemote: false,
+            },
+          ],
+          mode: ["off", { ignore: [] }],
+        },
+      },
+    } as ICache,
+  };
+});
+
+const resetMockedCache = () => {
+  const DEFAULT_ROOT_FOLDER = "test";
+  const VARIABLES_FILE = "path";
+  CACHE.activeRootPath = DEFAULT_ROOT_FOLDER;
+  CACHE.cssVarsMap[DEFAULT_ROOT_FOLDER] = {};
+  CACHE.config = {
+    [DEFAULT_ROOT_FOLDER]: {
+      ...DEFAULT_CONFIG,
+      files: [
+        {
+          local: VARIABLES_FILE,
+          remote: "",
+          isRemote: false,
+        },
+      ],
+      mode: ["off", { ignore: [] }],
+    },
+  };
+};
+
+beforeEach(() => {
+  resetMockedCache();
+});
+
+test("Should not return diagnostics when turned off", () => {
+  const docStub = new TextDocumentStub("color: var(--brand-primary);");
+  const diagnosticCollectionStub = new DiagnosticCollectionStub("foo");
+
+  // Update Mocked Cache values:
+  CACHE.cssVarCount[CACHE.activeRootPath] = 1;
+
+  refreshDiagnostics(
+    <TextDocument>(<unknown>docStub),
+    <DiagnosticCollection>(<unknown>diagnosticCollectionStub)
+  );
+
+  expect(diagnosticCollectionStub.get("foo")).toBe(undefined);
+});
+
+test("Should return diagnostics when turned on", () => {
+  CACHE.cssVarsMap[CACHE.activeRootPath] = {
+    // We don't have variable cached that we are looking for.
+    "--brand-secondary": {} as unknown as CSSVarDeclarations,
+  };
+  const docStub = new TextDocumentStub(`
+  color: var(--brand-secondary);
+  color: var(--brand-primary);
+  `);
+  const diagnosticCollectionStub = new DiagnosticCollectionStub("foo");
+
+  // Update Mocked Cache values:
+  CACHE.cssVarCount[CACHE.activeRootPath] = 1;
+  CACHE.config[CACHE.activeRootPath].mode[0] = "error";
+
+  refreshDiagnostics(
+    <TextDocument>(<unknown>docStub),
+    <DiagnosticCollection>(<unknown>diagnosticCollectionStub)
+  );
+
+  expect(diagnosticCollectionStub.get("foo")).not.toBeNull();
+  expect(diagnosticCollectionStub.get("foo").length).toBe(1);
+  expect(diagnosticCollectionStub.get("foo")[0]).toMatchObject({
+    desc: `Cannot find cssvar --brand-primary.`
+  })
+});
+
+test("Should ignore variables which are added to `ignore` list", () => {
+  CACHE.cssVarsMap[CACHE.activeRootPath] = {
+    // We don't have variable cached that we are looking for.
+    "--brand-secondary": {} as unknown as CSSVarDeclarations,
+  };
+  const docStub = new TextDocumentStub(`
+  color: var(--brand-secondary);
+  color: var(--brand-primary);
+  `);
+  const diagnosticCollectionStub = new DiagnosticCollectionStub("foo");
+
+  // Update Mocked Cache values:
+  CACHE.cssVarCount[CACHE.activeRootPath] = 1;
+  CACHE.config[CACHE.activeRootPath].mode[0] = "error";
+  CACHE.config[CACHE.activeRootPath].mode[1] = {
+    ignore: ["--brand-primary"]
+  };
+
+  refreshDiagnostics(
+    <TextDocument>(<unknown>docStub),
+    <DiagnosticCollection>(<unknown>diagnosticCollectionStub)
+  );
+
+  // Since the logic runs, an empty set of diagnostics will be set to the collection.
+  expect(diagnosticCollectionStub.get("foo").length).toBe(0);
+});

--- a/src/test/test-utilities.ts
+++ b/src/test/test-utilities.ts
@@ -6,3 +6,41 @@ export const getLocalCSSVarLocation = (path: string) =>
     remote: "",
     isRemote: false,
   } as CSSVarLocation);
+
+export class TextDocumentStub {
+  private document: string;
+  private _uri: string;
+  lineCount: number;
+  lines: string[] = [];
+
+  constructor(doc: string, uri = "foo") {
+    this.document = doc;
+    this.lines = doc.split("\n");
+    this.lineCount = this.lines.length;
+    this._uri = uri;
+  }
+
+  // I have used a getter here, so that I can spy it if I want
+  get uri() {
+    return this._uri;
+  }
+
+  getText = jest.fn().mockImplementation(() => this.document);
+  lineAt = jest.fn().mockImplementation((index: number) => ({ text: this.lines[index] }));
+}
+
+export class DiagnosticCollectionStub {
+  private name: string;
+  private map: Map<string, any> = new Map();
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  set = jest.fn().mockImplementation((uri: string, obj: any) => {
+    this.map.set(uri, obj);
+  })
+  get = jest.fn().mockImplementation((uri: string) => {
+    return this.map.get(uri);
+  })
+}

--- a/src/test/theming-and-duplicates.test.ts
+++ b/src/test/theming-and-duplicates.test.ts
@@ -25,6 +25,7 @@ const CONFIG: ConfigRecord = {
   [CACHE.activeRootPath]: {
     ...DEFAULT_CONFIG,
     files: [getLocalCSSVarLocation(THEMING_CSS)],
+    mode: ["off", { ignore: [] }],
   },
 };
 


### PR DESCRIPTION
Closes #73 

## Changes:

- New setting added to this extension: `cssvar.mode` (similar syntax to eslint rules property)
  - Set extension `mode` to `warn` or `error` to enable this new feature.
- Minor fixes to debug logs.
- Fixes definition and color providers with variable function using spaces in between parenthesis.

## Notes:

Since CSS variables are global in nature by default and can be used even without them being declared, an ideal CSS linter for CSS variables might not exist.
This feature enables strict checks for undeclared variables, thus variables which are undeclared or dynamically created will be considered as lint warn/errors.

**_For e.g. all the following CSS examples are valid:_**

```css
body {
  /* The following `--undeclared` variable does not exist */
  /* but its usage is completely valid, even though this extension */
  /* shows it as an error after enabling this feature */
  color: var(--undeclared, #333);
}
```

- In the following example variable is declared dynamically in CSS-in-JS

```js
// source.js
const foo = (index, value) => (
  css`
    --color-${index}: ${value};
  `
);
```

```css
/* index.css */
body {
  color: var(--color-1);
}
```

To fix the above cases, you can pass a list of variable names in the extension settings to ignore them, as follows:

```jsonc
// settings.json
{
  "cssvar.mode": ["warn", {
    "ignore": [
      "^--undeclared",
      "--color-\\w+?"
    ]
  }]
}
```

For details check the [examples folder](https://github.com/willofindie/vscode-cssvar/blob/main/examples/safe-parser/.vscode/settings.json)