### PR TITLE
[Feat] Support plugin options syntax

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -22,3 +22,4 @@
 - Good read to understand CSS Syntax: [Tokenizer and Parser](https://drafts.csswg.org/css-syntax/)
 - Good vscode extension to take insights from
   - https://github.com/znck/grammarly/blob/main/package.json
+- https://stackoverflow.com/a/15673308/2849127

--- a/TASKS.md
+++ b/TASKS.md
@@ -13,6 +13,8 @@
   - Open `css-imports` project -> After the files are parsed, update any import for `open-props` with a new
     granular css import, like `open-props/red.min.css`.
   - Doing this still shows `open-props/open-props.min.css` in the autocomplete/definition-provider list.
+- Support variable defaults syntax as well, like the following:
+  - `color: var(--color, #333)`, this is a valid syntax.
 
 
 ## Notes:

--- a/examples/with-plugins/.vscode/settings.json
+++ b/examples/with-plugins/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "cssvar.files": [
+    "src/tailwind.css",
+    "src/other.css",
+  ],
+  "cssvar.postcssPlugins": [
+    ["postcss-import"],
+    ["postcss-nested", {
+      "unwrap": ["phone"]
+    }],
+
+    // Use tailwindcss plugin with precaution, as it
+    // processes every css passed to this extension.
+    // Always use `cssvar.files` to properly define your source files
+    // when using tailwindcss, to keep this extension parsing fast enough.
+    "tailwindcss",
+
+    // Do not use `postcss-preset-env` plugin, as it makes the extension
+    // parsing pretty slow, which happens on each source file change.
+    // "postcss-preset-env"
+  ],
+}

--- a/examples/with-plugins/package.json
+++ b/examples/with-plugins/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "with-plugins",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "postcss-import": "^15.0.0",
+    "postcss-nested": "^5.0.6",
+    "tailwindcss": "^3.1.8"
+  }
+}

--- a/examples/with-plugins/pnpm-lock.yaml
+++ b/examples/with-plugins/pnpm-lock.yaml
@@ -1,0 +1,466 @@
+lockfileVersion: 5.4
+
+specifiers:
+  postcss-import: ^15.0.0
+  postcss-nested: ^5.0.6
+  tailwindcss: ^3.1.8
+
+dependencies:
+  postcss-import: 15.0.0
+  postcss-nested: 5.0.6
+  tailwindcss: 3.1.8
+
+packages:
+
+  /@nodelib/fs.scandir/2.1.5:
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+    dev: false
+
+  /@nodelib/fs.stat/2.0.5:
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+    dev: false
+
+  /@nodelib/fs.walk/1.2.8:
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.13.0
+    dev: false
+
+  /acorn-node/1.8.2:
+    resolution: {integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==}
+    dependencies:
+      acorn: 7.4.1
+      acorn-walk: 7.2.0
+      xtend: 4.0.2
+    dev: false
+
+  /acorn-walk/7.2.0:
+    resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
+  /acorn/7.4.1:
+    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
+
+  /anymatch/3.1.2:
+    resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+    dev: false
+
+  /arg/5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+    dev: false
+
+  /binary-extensions/2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /braces/3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.0.1
+    dev: false
+
+  /camelcase-css/2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+    dev: false
+
+  /chokidar/3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.2
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
+  /color-name/1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: false
+
+  /cssesc/3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
+
+  /defined/1.0.0:
+    resolution: {integrity: sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==}
+    dev: false
+
+  /detective/5.2.1:
+    resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+    dependencies:
+      acorn-node: 1.8.2
+      defined: 1.0.0
+      minimist: 1.2.6
+    dev: false
+
+  /didyoumean/1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+    dev: false
+
+  /dlv/1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    dev: false
+
+  /fast-glob/3.2.12:
+    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: false
+
+  /fastq/1.13.0:
+    resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
+    dependencies:
+      reusify: 1.0.4
+    dev: false
+
+  /fill-range/7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
+    dev: false
+
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /function-bind/1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: false
+
+  /glob-parent/5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: false
+
+  /glob-parent/6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: false
+
+  /has/1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      function-bind: 1.1.1
+    dev: false
+
+  /is-binary-path/2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.2.0
+    dev: false
+
+  /is-core-module/2.10.0:
+    resolution: {integrity: sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==}
+    dependencies:
+      has: 1.0.3
+    dev: false
+
+  /is-extglob/2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /is-glob/4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+    dev: false
+
+  /is-number/7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+    dev: false
+
+  /lilconfig/2.0.6:
+    resolution: {integrity: sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /merge2/1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+    dev: false
+
+  /micromatch/4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
+    dependencies:
+      braces: 3.0.2
+      picomatch: 2.3.1
+    dev: false
+
+  /minimist/1.2.6:
+    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+    dev: false
+
+  /nanoid/3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: false
+
+  /normalize-path/3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /object-hash/3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+    dev: false
+
+  /path-parse/1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: false
+
+  /picocolors/1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: false
+
+  /picomatch/2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: false
+
+  /pify/2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /postcss-import/14.1.0_postcss@8.4.17:
+    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.17
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+    dev: false
+
+  /postcss-import/15.0.0:
+    resolution: {integrity: sha512-Y20shPQ07RitgBGv2zvkEAu9bqvrD77C9axhj/aA1BQj4czape2MdClCExvB27EwYEJdGgKZBpKanb0t1rK2Kg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+    dev: false
+
+  /postcss-js/4.0.0_postcss@8.4.17:
+    resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.17
+    dev: false
+
+  /postcss-load-config/3.1.4_postcss@8.4.17:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.0.6
+      postcss: 8.4.17
+      yaml: 1.10.2
+    dev: false
+
+  /postcss-nested/5.0.6:
+    resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss-selector-parser: 6.0.10
+    dev: false
+
+  /postcss-nested/5.0.6_postcss@8.4.17:
+    resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss: 8.4.17
+      postcss-selector-parser: 6.0.10
+    dev: false
+
+  /postcss-selector-parser/6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+    dev: false
+
+  /postcss-value-parser/4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+    dev: false
+
+  /postcss/8.4.17:
+    resolution: {integrity: sha512-UNxNOLQydcOFi41yHNMcKRZ39NeXlr8AxGuZJsdub8vIb12fHzcq37DTU/QtbI6WLxNg2gF9Z+8qtRwTj1UI1Q==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: false
+
+  /queue-microtask/1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: false
+
+  /quick-lru/5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /read-cache/1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+    dependencies:
+      pify: 2.3.0
+    dev: false
+
+  /readdirp/3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
+    dev: false
+
+  /resolve/1.22.1:
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.10.0
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: false
+
+  /reusify/1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: false
+
+  /run-parallel/1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    dependencies:
+      queue-microtask: 1.2.3
+    dev: false
+
+  /source-map-js/1.0.2:
+    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /supports-preserve-symlinks-flag/1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /tailwindcss/3.1.8:
+    resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.12
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.0.6
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.17
+      postcss-import: 14.1.0_postcss@8.4.17
+      postcss-js: 4.0.0_postcss@8.4.17
+      postcss-load-config: 3.1.4_postcss@8.4.17
+      postcss-nested: 5.0.6_postcss@8.4.17
+      postcss-selector-parser: 6.0.10
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: false
+
+  /to-regex-range/5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
+    dev: false
+
+  /util-deprecate/1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: false
+
+  /xtend/4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+    dev: false
+
+  /yaml/1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+    dev: false

--- a/examples/with-plugins/src/index.css
+++ b/examples/with-plugins/src/index.css
@@ -1,0 +1,5 @@
+body {
+  color: var(--base);
+  color: var(--color-1);
+  padding: var(--tw-border-spacing-x) var(--tw-border-spacing-y);
+}

--- a/examples/with-plugins/src/other.css
+++ b/examples/with-plugins/src/other.css
@@ -1,0 +1,7 @@
+:root {
+  --base: #333;
+  --color-1: red;
+  --color-2: green;
+  --color-3: blue;
+}
+

--- a/examples/with-plugins/src/tailwind.css
+++ b/examples/with-plugins/src/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/examples/with-plugins/tailwind.config.js
+++ b/examples/with-plugins/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./src/**/*.css"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/feature-contributions.md
+++ b/feature-contributions.md
@@ -195,12 +195,23 @@ This Extension supports the following properties as of now:
   <tr align="left">
     <td>
       <code>cssvar.postcssPlugins</code>
+      <br>Provide PostCSS Plugins to support custom CSS features
     </td>
     <td>
-      <br>Provide PostCSS Plugins to support custom CSS features
-      <br>E.g.<pre lang="js">["postcss-nested"]</pre>
+      <br>E.g.
+      <pre lang="js">["postcss-nested"]</pre>
+      Or
+      <pre lang="js">[[
+  "postcss-nested",
+  {"unwrap": ["phone"]}
+]]</pre>
     </td>
-    <td><code>string[]</code></td>
+        </td>
+    <td><pre lang="ts">string[]
+| [
+    string,
+    object
+  ][]</pre></td>
     <td>
       <br>
       <pre lang="js">[]</pre>

--- a/feature-contributions.md
+++ b/feature-contributions.md
@@ -213,7 +213,7 @@ This Extension supports the following properties as of now:
       <br>Enable/Disable CSS variable linting modes.
     </td>
     <td>
-      E.g.<pre lang="js">["error", {
+      <br>E.g.<pre lang="js">["error", {
   ignore: [
     "--dynamic",
     "dy[nN].*?c$"

--- a/package.json
+++ b/package.json
@@ -219,7 +219,15 @@
 					],
 					"default": null,
 					"items": {
-						"type": "string"
+						"oneOf": [
+							{ "type": "string" },
+							{ "type": "array", "items": [{
+								"type": "string"
+							}, {
+								"type": "object",
+								"default": {}
+							}]}
+						]
 					},
 					"markdownDescription": "Provide __PostCSS__ plugins to support custom CSS features. List of __PostCSS__ plugin names can be found in [PostCSS Doc](https://github.com/postcss/postcss#plugins)",
 					"scope": "resource",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -67,7 +67,7 @@ export interface Config {
   extensions: SupportedExtensionNames[];
   themes: string[];
   mode: [LintingSeverity, { ignore?: RegExp | null }];
-  postcssPlugins: string[];
+  postcssPlugins: [string, Record<string, any>][];
   postcssSyntax: Record<string, string>;
   excludeThemedVariables: boolean;
   disableSort: boolean;
@@ -76,9 +76,13 @@ export interface Config {
   enableHover: boolean;
 }
 
-export type WorkspaceConfig = Omit<Config, "files" | "mode"> & {
+export type WorkspaceConfig = Omit<
+  Config,
+  "files" | "mode" | "postcssPlugins"
+> & {
   files: string[];
   mode: LintingSeverity | [LintingSeverity, { ignore: string[] }];
+  postcssPlugins: string[] | [string, Record<string, any>][];
 };
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,7 +66,7 @@ export interface Config {
   ignore: string[];
   extensions: SupportedExtensionNames[];
   themes: string[];
-  mode: [LintingSeverity, { ignore: string[] }];
+  mode: [LintingSeverity, { ignore?: RegExp | null }];
   postcssPlugins: string[];
   postcssSyntax: Record<string, string>;
   excludeThemedVariables: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,6 +121,26 @@ export async function setup(): Promise<{
             });
             break;
           }
+          case "postcssPlugins": {
+            const _plugins =
+              _config.get<WorkspaceConfig["postcssPlugins"]>(key);
+            let plugins: Config["postcssPlugins"] = [];
+            if (_plugins) {
+              plugins = _plugins
+                .map(plugin => {
+                  if (Array.isArray(plugin) && plugin.length > 0) {
+                    return [plugin[0], plugin[1] || {}];
+                  } else if (typeof plugin === "string") {
+                    return [plugin, {}];
+                  } else {
+                    return null;
+                  }
+                })
+                .filter(Boolean) as Config["postcssPlugins"];
+            }
+            config[fsPathKey][key] = plugins;
+            break;
+          }
           case "postcssSyntax": {
             const syntaxes = _config.get<Record<string, string[]>>(key);
             if (syntaxes && !Array.isArray(syntaxes)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,15 +145,26 @@ export async function setup(): Promise<{
             const mode = _config.get<WorkspaceConfig["mode"]>(key);
             let _mode: Config["mode"];
             if (typeof mode === "string") {
-              _mode = [mode, { ignore: [] }];
+              _mode = [mode, {}];
             } else if (
               Array.isArray(mode) &&
               mode.length > 0 &&
               mode.length < 3
             ) {
-              _mode = [mode[0], mode[1] || { ignore: [] }];
+              let ignoreRegex = null;
+              if (mode[1].ignore.length > 0) {
+                ignoreRegex = new RegExp(
+                  mode[1].ignore
+                    .reduce((str, current) => {
+                      str.push(`(${current})`);
+                      return str;
+                    }, [] as string[])
+                    .join("|")
+                );
+              }
+              _mode = [mode[0], { ignore: ignoreRegex || null }];
             } else {
-              _mode = ["off", { ignore: [] }];
+              _mode = ["off", {}];
             }
             config[fsPathKey][key] = _mode;
             break;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -59,10 +59,10 @@ const cssParseAsync = async (
   const plugins = CACHE.config[rootPath].postcssPlugins
     .map(plugin => {
       try {
-        const resolvedMod = require(require.resolve(plugin, {
+        const resolvedMod = require(require.resolve(plugin[0], {
           paths: rootPathsOrUndefined,
         }));
-        return resolvedMod;
+        return resolvedMod(plugin[1]);
       } catch (e: any) {
         window.showErrorMessage(
           `Cannot resolve postcss plugin ${plugin}. Please add postcss@8 as project's dependency.`

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -20,17 +20,7 @@ function createDiagnostic(
 ): Diagnostic | null {
   const variableName = match[1].trim();
   const mode = CACHE.config[CACHE.activeRootPath].mode;
-  let ignoreRegex = null;
-  if (mode[1].ignore.length > 0) {
-    ignoreRegex = new RegExp(
-      mode[1].ignore
-        .reduce((str, current) => {
-          str.push(`(${current})`);
-          return str;
-        }, [] as string[])
-        .join("|")
-    );
-  }
+  const ignoreRegex = mode[1].ignore;
   if (
     CACHE.cssVarsMap[CACHE.activeRootPath][variableName] ||
     (ignoreRegex && ignoreRegex.test(variableName))

--- a/src/test/main.test.ts
+++ b/src/test/main.test.ts
@@ -26,14 +26,16 @@ describe("Test Extension Main", () => {
     it("Should return CompletionItems with Sorting On", async () => {
       const config: Config = {
         ...DEFAULT_CONFIG,
-        files: [{
-          local: "",
-          remote: "",
-          isRemote: false,
-        }],
-        mode: ["off", { ignore: [] }],
+        files: [
+          {
+            local: "",
+            remote: "",
+            isRemote: false,
+          },
+        ],
+        mode: ["off", {}],
         disableSort: false,
-      }
+      };
       const cssVars: CSSVarRecord = {
         "./src/01.css": [
           {
@@ -68,14 +70,16 @@ describe("Test Extension Main", () => {
     it("Should return CompletionItems with Sorting Disabled", async () => {
       const config: Config = {
         ...DEFAULT_CONFIG,
-        files: [{
-          local: "",
-          remote: "",
-          isRemote: false,
-        }],
-        mode: ["off", { ignore: [] }],
+        files: [
+          {
+            local: "",
+            remote: "",
+            isRemote: false,
+          },
+        ],
+        mode: ["off", {}],
         disableSort: true,
-      }
+      };
       const cssVars: CSSVarRecord = {
         "./src/01.css": [
           {
@@ -114,9 +118,9 @@ describe("Test Extension Main", () => {
       const config: Config = {
         ...DEFAULT_CONFIG,
         files: [getLocalCSSVarLocation("")],
-        mode: ["off", { ignore: [] }],
+        mode: ["off", {}],
         disableSort: true,
-      }
+      };
       const cssVars1: CSSVarRecord = Array(11)
         .fill([
           {

--- a/src/test/main.test.ts
+++ b/src/test/main.test.ts
@@ -1,5 +1,5 @@
-import { Position, Range } from "vscode";
-import { Config, CSSVarRecord, DEFAULT_CONFIG } from "../constants";
+import { Position, Range, workspace } from "vscode";
+import { Config, CSSVarRecord, DEFAULT_CONFIG, CACHE } from "../constants";
 import { createCompletionItems } from "../main";
 import { Region } from "../utils";
 import { getLocalCSSVarLocation } from "./test-utilities";
@@ -12,6 +12,43 @@ jest.mock("../constants", () => ({
 }));
 
 let region: Region | null = null;
+const DEFAULT_ROOT_FOLDER = "test";
+
+beforeEach(() => {
+  CACHE.activeRootPath = DEFAULT_ROOT_FOLDER;
+  CACHE.config = {
+    [CACHE.activeRootPath]: {
+      ...DEFAULT_CONFIG,
+      files: [
+        {
+          local: "",
+          remote: "",
+          isRemote: false,
+        },
+      ],
+      postcssPlugins: [],
+      mode: ["off", {}],
+      disableSort: false,
+    },
+  } as Record<string, Config>;
+});
+
+beforeAll(() => {
+  // @ts-ignore
+  workspace.workspaceFolders = [
+    {
+      uri: {
+        path: DEFAULT_ROOT_FOLDER,
+        fsPath: DEFAULT_ROOT_FOLDER,
+      },
+    },
+  ];
+});
+
+afterAll(() => {
+  // @ts-ignore Reset to default
+  workspace.workspaceFolders = [];
+})
 
 describe("Test Extension Main", () => {
   beforeEach(() => {
@@ -33,6 +70,7 @@ describe("Test Extension Main", () => {
             isRemote: false,
           },
         ],
+        postcssPlugins: [],
         mode: ["off", {}],
         disableSort: false,
       };
@@ -77,6 +115,7 @@ describe("Test Extension Main", () => {
             isRemote: false,
           },
         ],
+        postcssPlugins: [],
         mode: ["off", {}],
         disableSort: true,
       };
@@ -118,6 +157,7 @@ describe("Test Extension Main", () => {
       const config: Config = {
         ...DEFAULT_CONFIG,
         files: [getLocalCSSVarLocation("")],
+        postcssPlugins: [],
         mode: ["off", {}],
         disableSort: true,
       };
@@ -178,4 +218,9 @@ describe("Test Extension Main", () => {
       );
     });
   });
+});
+
+// Need to work on this later.
+test.skip("setup() should map user config to in-mem Config object", () => {
+
 });

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -38,6 +38,7 @@ const EXTENSION_CONFIG: ConfigRecord = {
     ...DEFAULT_CONFIG,
     files: [getLocalCSSVarLocation(DUMMY_FILE)],
     mode: ["off", {}],
+    postcssPlugins: [],
   },
 };
 
@@ -262,12 +263,14 @@ describe("Multi Root", () => {
         ...DEFAULT_CONFIG,
         files: [getLocalCSSVarLocation(IMPORT_SCSS_FILE)],
         mode: ["off", {}],
+        postcssPlugins: [],
       },
       [rootPath2]: {
         // This config will test SCSS files
         ...DEFAULT_CONFIG,
         files: [getLocalCSSVarLocation(RENAMED_FILE)],
         mode: ["off", {}],
+        postcssPlugins: [],
       },
     };
     CACHE.config = config;

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -29,7 +29,7 @@ jest.mock("../constants", () => {
   };
 });
 
-jest.mock('../remote-paths');
+jest.mock("../remote-paths");
 
 type ConfigRecord = { [rootFolder: string]: Config };
 
@@ -37,7 +37,7 @@ const EXTENSION_CONFIG: ConfigRecord = {
   [CACHE.activeRootPath]: {
     ...DEFAULT_CONFIG,
     files: [getLocalCSSVarLocation(DUMMY_FILE)],
-    mode: ["off", { ignore: [] }],
+    mode: ["off", {}],
   },
 };
 
@@ -135,11 +135,13 @@ describe("Test Parser", () => {
       const updatedConfig: ConfigRecord = {
         [CACHE.activeRootPath]: {
           ...EXTENSION_CONFIG[CACHE.activeRootPath],
-          files: [{
-            local: path.resolve(__dirname, "fixtures/theming.css"), // Does nothing, just to make jest happy
-            remote: "http://example.com/v0.12.3/foo.css",
-            isRemote: true,
-          }],
+          files: [
+            {
+              local: path.resolve(__dirname, "fixtures/theming.css"), // Does nothing, just to make jest happy
+              remote: "http://example.com/v0.12.3/foo.css",
+              isRemote: true,
+            },
+          ],
         },
       };
 
@@ -148,7 +150,7 @@ describe("Test Parser", () => {
       jest.resetAllMocks();
       await parseFiles(updatedConfig);
       expect(fetchAndCacheAsset).toHaveBeenCalledTimes(0);
-    })
+    });
   });
 
   describe("parseFiles handle improper CSS Files", () => {
@@ -157,7 +159,10 @@ describe("Test Parser", () => {
       const updatedConfig: ConfigRecord = {
         [CACHE.activeRootPath]: {
           ...EXTENSION_CONFIG[CACHE.activeRootPath],
-          files: [getLocalCSSVarLocation(RENAMED_FILE), getLocalCSSVarLocation(BROKEN_FILE)],
+          files: [
+            getLocalCSSVarLocation(RENAMED_FILE),
+            getLocalCSSVarLocation(BROKEN_FILE),
+          ],
         },
       };
       CACHE.config = updatedConfig;
@@ -248,7 +253,7 @@ describe("Multi Root", () => {
   afterAll(() => {
     // @ts-ignore
     workspace.workspaceFolders = [];
-  })
+  });
 
   it(`should have proper values for each root folder`, async () => {
     const config: ConfigRecord = {
@@ -256,13 +261,13 @@ describe("Multi Root", () => {
         // This config will test SCSS files
         ...DEFAULT_CONFIG,
         files: [getLocalCSSVarLocation(IMPORT_SCSS_FILE)],
-        mode: ["off", { ignore: [] }],
+        mode: ["off", {}],
       },
       [rootPath2]: {
         // This config will test SCSS files
         ...DEFAULT_CONFIG,
         files: [getLocalCSSVarLocation(RENAMED_FILE)],
-        mode: ["off", { ignore: [] }],
+        mode: ["off", {}],
       },
     };
     CACHE.config = config;

--- a/src/test/pre-processors/template-literals.test.ts
+++ b/src/test/pre-processors/template-literals.test.ts
@@ -27,6 +27,7 @@ const MOCK_CONFIG: ConfigRecord = {
     ...DEFAULT_CONFIG,
     files: [getLocalCSSVarLocation(JSX_FILE_PATH)],
     mode: ["off", {}],
+    postcssPlugins: [],
   },
 };
 

--- a/src/test/pre-processors/template-literals.test.ts
+++ b/src/test/pre-processors/template-literals.test.ts
@@ -26,7 +26,7 @@ const MOCK_CONFIG: ConfigRecord = {
   [CACHE.activeRootPath]: {
     ...DEFAULT_CONFIG,
     files: [getLocalCSSVarLocation(JSX_FILE_PATH)],
-    mode: ["off", { ignore: [] }],
+    mode: ["off", {}],
   },
 };
 
@@ -132,12 +132,16 @@ beforeAll(() => {
 
 test("should have proper variables present", () => {
   for (const result of RESULTS) {
-    expect(globalVarRecord[JSX_FILE_PATH]).toContainEqual(expect.objectContaining(result));
+    expect(globalVarRecord[JSX_FILE_PATH]).toContainEqual(
+      expect.objectContaining(result)
+    );
   }
 });
 
 test("should not have improper variables", () => {
   for (const wrong of WRONG_RESULTS) {
-    expect(globalVarRecord[JSX_FILE_PATH]).not.toContainEqual(expect.objectContaining(wrong));
+    expect(globalVarRecord[JSX_FILE_PATH]).not.toContainEqual(
+      expect.objectContaining(wrong)
+    );
   }
 });

--- a/src/test/providers/diagnostics.test.ts
+++ b/src/test/providers/diagnostics.test.ts
@@ -52,7 +52,7 @@ const resetMockedCache = () => {
           isRemote: false,
         },
       ],
-      mode: ["off", { ignore: [] }],
+      mode: ["off", {}],
     },
   };
 };
@@ -99,8 +99,8 @@ test("Should return diagnostics when turned on", () => {
   expect(diagnosticCollectionStub.get("foo")).not.toBeNull();
   expect(diagnosticCollectionStub.get("foo").length).toBe(1);
   expect(diagnosticCollectionStub.get("foo")[0]).toMatchObject({
-    desc: `Cannot find cssvar --brand-primary.`
-  })
+    desc: `Cannot find cssvar --brand-primary.`,
+  });
 });
 
 test("Should ignore variables which are added to `ignore` list", () => {
@@ -118,7 +118,7 @@ test("Should ignore variables which are added to `ignore` list", () => {
   CACHE.cssVarCount[CACHE.activeRootPath] = 1;
   CACHE.config[CACHE.activeRootPath].mode[0] = "error";
   CACHE.config[CACHE.activeRootPath].mode[1] = {
-    ignore: ["--brand-primary"]
+    ignore: new RegExp("--brand-primary"),
   };
 
   refreshDiagnostics(

--- a/src/test/providers/diagnostics.test.ts
+++ b/src/test/providers/diagnostics.test.ts
@@ -53,6 +53,7 @@ const resetMockedCache = () => {
         },
       ],
       mode: ["off", {}],
+      postcssPlugins: [],
     },
   };
 };

--- a/src/test/theming-and-duplicates.test.ts
+++ b/src/test/theming-and-duplicates.test.ts
@@ -25,7 +25,7 @@ const CONFIG: ConfigRecord = {
   [CACHE.activeRootPath]: {
     ...DEFAULT_CONFIG,
     files: [getLocalCSSVarLocation(THEMING_CSS)],
-    mode: ["off", { ignore: [] }],
+    mode: ["off", {}],
   },
 };
 

--- a/src/test/theming-and-duplicates.test.ts
+++ b/src/test/theming-and-duplicates.test.ts
@@ -26,6 +26,7 @@ const CONFIG: ConfigRecord = {
     ...DEFAULT_CONFIG,
     files: [getLocalCSSVarLocation(THEMING_CSS)],
     mode: ["off", {}],
+    postcssPlugins: [],
   },
 };
 


### PR DESCRIPTION
Now users can pass supported options to PostCSS plugins using the following syntax.

```jsonc
{
  "cssvar.postcssPlugins": [
    // [ name, options ]
    [ "postcss-nested", {"unwrap": ["phone"]} ],
  ]
}
```