### PR TITLE
[Revert] #74 Support for `.gitignore`

### DIFF
--- a/package.json
+++ b/package.json
@@ -429,7 +429,7 @@
 	},
 	"dependencies": {
 		"culori": "^2.0.3",
-		"globby": "^13.1.2",
+		"fast-glob": "^3.2.12",
 		"postcss": "^8.4.12",
 		"postcss-less": "^6.0.0"
 	},

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from "os";
 import { mkdirSync } from "fs";
 import { resolve } from "path";
-import { globby } from "globby";
+import fastGlob from "fast-glob";
 import {
   CACHE,
   Config,
@@ -92,9 +92,8 @@ export async function setup(): Promise<{
               },
               [[], []]
             );
-            const localEntries = await globby(localGlobs, {
+            const localEntries = await fastGlob(localGlobs, {
               cwd: resourcePath,
-              gitignore: true,
               ignore: ignoreList,
             });
             LOGGER.log("Source files: ", localEntries);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2628,7 +2628,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^3.2.11:
+fast-glob@^3.2.12:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
@@ -2822,17 +2822,6 @@ globby@^11.1.0:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
-
-globby@^13.1.2:
-  version "13.1.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.2.tgz#29047105582427ab6eca4f905200667b056da515"
-  integrity sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==
-  dependencies:
-    dir-glob "^3.0.1"
-    fast-glob "^3.2.11"
-    ignore "^5.2.0"
-    merge2 "^1.4.1"
-    slash "^4.0.0"
 
 graceful-fs@^4.2.9:
   version "4.2.10"
@@ -4119,11 +4108,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-slash@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
-  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
 slice-ansi@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Reverts #74 

`globby` seems to break the ignore files list passed by users when `.gitignore` contains ignored files that are ignored by users previously in `cssvar.ignore` config.