### PR TITLE
[Feat] Support `tokencss` | Adds custom plugin resolver for specific use-cases

### DIFF
--- a/@types/postcss.d.ts
+++ b/@types/postcss.d.ts
@@ -80,3 +80,7 @@ declare module "postcss/lib/parser" {
   }
   export default Parser;
 }
+
+declare module "@tokencss/postcss" {
+  export default function plugin(options?: any): void;
+}

--- a/esbuild.sh
+++ b/esbuild.sh
@@ -1,0 +1,8 @@
+npx esbuild ./src/extension.ts \
+  --external:vscode \
+    --external:"@tokencss/postcss" \
+  --format=cjs \
+  --platform=node \
+  --target=node16 \
+  --outfile=out/extension.js \
+  --bundle --minify --define:process.env.NODE_ENV='"production"'

--- a/examples/tokencss-plugin/.vscode/settings.json
+++ b/examples/tokencss-plugin/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cssvar.postcssPlugins": [
+    ["@tokencss/postcss", { "cwd": "examples/tokencss-plugin/config" }]
+  ]
+}

--- a/examples/tokencss-plugin/base.css
+++ b/examples/tokencss-plugin/base.css
@@ -1,0 +1,5 @@
+@inject "tokencss:base";
+
+:root {
+  --color-red: red;
+}

--- a/examples/tokencss-plugin/config/token.config.json
+++ b/examples/tokencss-plugin/config/token.config.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://tokencss.com/schema@0.0.1",
+  "extends": ["@tokencss/core/preset"]
+}

--- a/examples/tokencss-plugin/index.css
+++ b/examples/tokencss-plugin/index.css
@@ -1,0 +1,4 @@
+body {
+  color: var(--color-red-2);
+  padding: var(--space-2xl);
+}

--- a/examples/tokencss-plugin/package.json
+++ b/examples/tokencss-plugin/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tokencss-plugin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@tokencss/core": "^0.1.0",
+    "@tokencss/postcss": "^0.0.5"
+  }
+}

--- a/examples/tokencss-plugin/pnpm-lock.yaml
+++ b/examples/tokencss-plugin/pnpm-lock.yaml
@@ -1,0 +1,90 @@
+lockfileVersion: 5.4
+
+specifiers:
+  '@tokencss/core': ^0.1.0
+  '@tokencss/postcss': ^0.0.5
+
+dependencies:
+  '@tokencss/core': 0.1.0
+  '@tokencss/postcss': 0.0.5
+
+packages:
+
+  /@proload/core/0.2.2:
+    resolution: {integrity: sha512-HYQEblYXIpW77kvGyW4penEl9D9e9MouPhTqVaDz9+QVFliYjsq18inTfnfTa81s3oraPVtTk60tqCWOf2fKGQ==}
+    dependencies:
+      deepmerge: 4.2.2
+      escalade: 3.1.1
+    dev: false
+
+  /@proload/plugin-json/0.2.0_@proload+core@0.2.2:
+    resolution: {integrity: sha512-uZRA24JC7PMyT092D1EgcHxoGexAwmPltet/WPKVUL+bQ03Y5AceDL672XaUPCaquL1CbAnurky+cp48yFQ+aA==}
+    peerDependencies:
+      '@proload/core': ^0.2.2
+    dependencies:
+      '@proload/core': 0.2.2
+      jsonc-register: 0.2.0
+    dev: false
+
+  /@tokencss/core/0.1.0:
+    resolution: {integrity: sha512-vSWoiZ1chaC4qqhAxbrRoEnPEGeRby1SQYf8ayqtui5+yizwp56A+WRev8xgugIuucH4Jbg4DkNvKcwc1XvzPg==}
+    dependencies:
+      dlv: 1.1.3
+    dev: false
+
+  /@tokencss/postcss/0.0.5:
+    resolution: {integrity: sha512-iv4php+M7s/Imrbla9WO0TcoedHaej1bl+74Un8pxttD7oGLk+CblqsbMs1DotES4C9BQEUiFG6tm0ezJ4c4hw==}
+    peerDependencies:
+      postcss: ^8.4.5
+    dependencies:
+      '@proload/core': 0.2.2
+      '@proload/plugin-json': 0.2.0_@proload+core@0.2.2
+      '@tokencss/core': 0.1.0
+      magic-string: 0.25.9
+      postcss-value-parser: 4.2.0
+    dev: false
+
+  /deepmerge/4.2.2:
+    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /dlv/1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    dev: false
+
+  /escalade/3.1.1:
+    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /jsonc-register/0.2.0:
+    resolution: {integrity: sha512-wzsgJUdIntyH0SsoMFf1K4SAEipHAtKTdY1OZakDY/azflRiSrK1CsVHgc0hHRhlJ3MtB91f6O9tkluQ1XUFsA==}
+    dependencies:
+      pirates: 4.0.5
+      strip-json-comments: 3.1.1
+    dev: false
+
+  /magic-string/0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: false
+
+  /pirates/4.0.5:
+    resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
+    engines: {node: '>= 6'}
+    dev: false
+
+  /postcss-value-parser/4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+    dev: false
+
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    dev: false
+
+  /strip-json-comments/3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+    dev: false

--- a/examples/with-plugins/.vscode/settings.json
+++ b/examples/with-plugins/.vscode/settings.json
@@ -2,6 +2,7 @@
   "cssvar.files": [
     "src/tailwind.css",
     "src/other.css",
+    "src/tokencss.css",
   ],
   "cssvar.postcssPlugins": [
     ["postcss-import"],
@@ -15,6 +16,7 @@
     // when using tailwindcss, to keep this extension parsing fast enough.
     "tailwindcss",
 
+    "@tokencss/postcss"
     // Do not use `postcss-preset-env` plugin, as it makes the extension
     // parsing pretty slow, which happens on each source file change.
     // "postcss-preset-env"

--- a/examples/with-plugins/src/index.css
+++ b/examples/with-plugins/src/index.css
@@ -1,5 +1,7 @@
 body {
   color: var(--base);
-  color: var(--color-1);
+  background-color: rgba(var(--color-teal-6-rgb) , 0.3);
+  color: var(--color-grape-5);
   padding: var(--tw-border-spacing-x) var(--tw-border-spacing-y);
+  scale: var(--tw-scale-x);
 }

--- a/examples/with-plugins/src/tokencss.css
+++ b/examples/with-plugins/src/tokencss.css
@@ -1,0 +1,1 @@
+@inject "tokencss:base";

--- a/examples/with-plugins/token.config.json
+++ b/examples/with-plugins/token.config.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://tokencss.com/schema@0.0.1",
+  "extends": ["@tokencss/core/preset"]
+}

--- a/package.json
+++ b/package.json
@@ -396,6 +396,7 @@
 		"@rollup/plugin-json": "^4.1.0",
 		"@rollup/plugin-node-resolve": "^11.2.1",
 		"@rollup/plugin-replace": "^4.0.0",
+		"@tokencss/postcss": "^0.0.5",
 		"@types/css": "^0.0.31",
 		"@types/glob": "^7.2.0",
 		"@types/jest": "^29.1.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,8 @@ export default [
     input: "src/extension.ts",
     external: ["vscode"],
     output: {
-      file: pkg.main,
+      // file: pkg.main,
+      dir: "out",
       format: "cjs",
     },
     plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,6 +1385,21 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@proload/core@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@proload/core/-/core-0.2.2.tgz#d6de30e06a8864bdd0fbe568f87d0582cf988c1d"
+  integrity sha512-HYQEblYXIpW77kvGyW4penEl9D9e9MouPhTqVaDz9+QVFliYjsq18inTfnfTa81s3oraPVtTk60tqCWOf2fKGQ==
+  dependencies:
+    deepmerge "^4.2.2"
+    escalade "^3.1.1"
+
+"@proload/plugin-json@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@proload/plugin-json/-/plugin-json-0.2.0.tgz#33479fb967aeedf71f7adeb4d247185e00dbba11"
+  integrity sha512-uZRA24JC7PMyT092D1EgcHxoGexAwmPltet/WPKVUL+bQ03Y5AceDL672XaUPCaquL1CbAnurky+cp48yFQ+aA==
+  dependencies:
+    jsonc-register "^0.2.0"
+
 "@rollup/plugin-commonjs@^18.1.0":
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-18.1.0.tgz#5a760d757af168a50727c0ae080251fbfcc5eb02"
@@ -1460,6 +1475,24 @@
   integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@tokencss/core@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@tokencss/core/-/core-0.1.0.tgz#77c237b20b88e0518d1a083d0f42653bd406f8ba"
+  integrity sha512-vSWoiZ1chaC4qqhAxbrRoEnPEGeRby1SQYf8ayqtui5+yizwp56A+WRev8xgugIuucH4Jbg4DkNvKcwc1XvzPg==
+  dependencies:
+    dlv "^1.1.3"
+
+"@tokencss/postcss@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@tokencss/postcss/-/postcss-0.0.5.tgz#6645b917b6f77f21c6d951d65592f3d1cbd96c50"
+  integrity sha512-iv4php+M7s/Imrbla9WO0TcoedHaej1bl+74Un8pxttD7oGLk+CblqsbMs1DotES4C9BQEUiFG6tm0ezJ4c4hw==
+  dependencies:
+    "@proload/core" "^0.2.2"
+    "@proload/plugin-json" "^0.2.0"
+    "@tokencss/core" "0.1.0"
+    magic-string "^0.25.7"
+    postcss-value-parser "^4.2.0"
 
 "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -2218,6 +2251,11 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+dlv@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
+  integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -3481,6 +3519,14 @@ jsonc-parser@^3.0.0:
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.1.0.tgz#73b8f0e5c940b83d03476bc2e51a20ef0932615d"
   integrity sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==
 
+jsonc-register@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/jsonc-register/-/jsonc-register-0.2.0.tgz#d56c341b7afdeb7c448d1dc99d1430ea98248ccd"
+  integrity sha512-wzsgJUdIntyH0SsoMFf1K4SAEipHAtKTdY1OZakDY/azflRiSrK1CsVHgc0hHRhlJ3MtB91f6O9tkluQ1XUFsA==
+  dependencies:
+    pirates "^4.0.1"
+    strip-json-comments "3.1.1"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -3814,7 +3860,7 @@ picomatch@^2.0.4, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pirates@^4.0.4:
+pirates@^4.0.1, pirates@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
@@ -3837,6 +3883,11 @@ postcss-less@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-6.0.0.tgz#463b34c60f53b648c237f569aeb2e09149d85af4"
   integrity sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==
+
+postcss-value-parser@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^8.1.2, postcss@^8.4.12, postcss@^8.4.4:
   version "8.4.14"
@@ -4215,7 +4266,7 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==


### PR DESCRIPTION
Closes #78 

- This PR breaks the 200KiB minified bundle size threshold
  - This can be improved later on, once ESM support is added to VSCode extensions. As of now because I am not able to find any workarounds, I had to bundle `@tokencss/postcss` to make it work in the production build.
- Future releases will focus on optimizing the current logic as well as the bundle size of the extension.