### PR TITLE
[Feat] Enable all useful language ids | add `enable` setting to enable/disable app per root folder

### DIFF
--- a/examples/multi-root/proj-1/.vscode/settings.json
+++ b/examples/multi-root/proj-1/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "cssvar.ignore": ["broken.css"]
+  "cssvar.ignore": ["broken.css"],
+  "cssvar.mode": "error"
 }

--- a/examples/multi-root/proj-2/.vscode/settings.json
+++ b/examples/multi-root/proj-2/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "cssvar.files": ["**/*.scss"],
+  "cssvar.extensions": ["scss"],
   "cssvar.mode": "warn"
 }

--- a/package.json
+++ b/package.json
@@ -109,6 +109,19 @@
 						]
 					]
 				},
+				"cssvar.enable": {
+					"type": [
+						"boolean",
+						"null"
+					],
+					"default": null,
+					"markdownDescription": "Enable/Disable extension for a workspace/folder",
+					"scope": "resource",
+					"examples": [
+						true,
+						false
+					]
+				},
 				"cssvar.extensions": {
 					"type": [
 						"array",

--- a/package.json
+++ b/package.json
@@ -44,13 +44,28 @@
 		"onLanguage:sass",
 		"onLanguage:less",
 		"onLanguage:postcss",
-		"onLanguage:svelte",
-		"onLanguage:vue",
-		"onLanguage:astro",
+		"onLanguage:stylus",
+		"onLanguage:sugarss",
+		"onLanguage:tailwindcss",
+
+		"onLanguage:django-html",
+		"onLanguage:ejs",
+		"onLanguage:gohtml",
+		"onLanguage:GoHTML",
+		"onLanguage:gohtmltmpl",
+		"onLanguage:handlebars",
+		"onLanguage:html",
+		"onLanguage:jade",
+
 		"onLanguage:javascript",
 		"onLanguage:javascriptreact",
 		"onLanguage:typescript",
-		"onLanguage:typescriptreact"
+		"onLanguage:typescriptreact",
+		"onLanguage:coffeescript",
+
+		"onLanguage:svelte",
+		"onLanguage:vue",
+		"onLanguage:astro"
 	],
 	"main": "./out/extension.js",
 	"preview": false,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -64,6 +64,7 @@ export interface Config {
   files: CSSVarLocation[];
   // Ignore could be a glob as well.
   ignore: string[];
+  enable: boolean;
   extensions: SupportedExtensionNames[];
   themes: string[];
   mode: [LintingSeverity, { ignore?: RegExp | null }];
@@ -93,6 +94,7 @@ export type WorkspaceConfig = Omit<
 export const DEFAULT_CONFIG: WorkspaceConfig = {
   files: ["**/*.css"],
   ignore: ["**/node_modules/**"],
+  enable: true,
   extensions: [...SUPPORTED_LANGUAGE_IDS],
   mode: "off",
   themes: [],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,9 @@ const watchers: FileSystemWatcher[] = [];
 export async function activate(context: ExtensionContext): Promise<void> {
   try {
     const { config } = await setup();
+    if (!config[CACHE.activeRootPath].enable) {
+      return;
+    }
     const [, errorPaths] = await parseFiles(config, { parseAll: true }); // Cache Parsed CSS Vars for all Root folders
     if (errorPaths.length > 0) {
       const relativePaths = errorPaths;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import {
 } from "vscode";
 import { CssColorProvider } from "./providers/color-provider";
 import { CssCompletionProvider } from "./providers/completion-provider";
-import { CACHE, DEFAULT_CONFIG, EXTENSION_NAME } from "./constants";
+import { CACHE, EXTENSION_NAME } from "./constants";
 import { CssDefinitionProvider } from "./providers/definition-provider";
 import { LOGGER } from "./logger";
 import { setup } from "./main";
@@ -30,6 +30,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     if (!config[CACHE.activeRootPath].enable) {
       return;
     }
+
     const [, errorPaths] = await parseFiles(config, { parseAll: true }); // Cache Parsed CSS Vars for all Root folders
     if (errorPaths.length > 0) {
       const relativePaths = errorPaths;
@@ -45,7 +46,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     );
 
     const completionDisposable = languages.registerCompletionItemProvider(
-      config[CACHE.activeRootPath].extensions || DEFAULT_CONFIG.extensions,
+      config[CACHE.activeRootPath].extensions,
       new CssCompletionProvider(),
       "-",
       "v",
@@ -57,7 +58,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
     if (config[CACHE.activeRootPath].enableColors) {
       const colorDisposable = languages.registerColorProvider(
-        config[CACHE.activeRootPath].extensions || DEFAULT_CONFIG.extensions,
+        config[CACHE.activeRootPath].extensions,
         new CssColorProvider()
       );
       context.subscriptions.push(colorDisposable);
@@ -65,7 +66,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
     if (config[CACHE.activeRootPath].enableGotoDef) {
       const definitionDisposable = languages.registerDefinitionProvider(
-        config[CACHE.activeRootPath].extensions || DEFAULT_CONFIG.extensions,
+        config[CACHE.activeRootPath].extensions,
         new CssDefinitionProvider()
       );
       context.subscriptions.push(definitionDisposable);
@@ -73,7 +74,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
     if (config[CACHE.activeRootPath].enableHover) {
       const definitionDisposable = languages.registerHoverProvider(
-        config[CACHE.activeRootPath].extensions || DEFAULT_CONFIG.extensions,
+        config[CACHE.activeRootPath].extensions,
         new CssHoverProvider()
       );
       context.subscriptions.push(definitionDisposable);

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -58,6 +58,9 @@ export function refreshDiagnostics(
   cssvarDiagnostics: DiagnosticCollection
 ): void {
   if (
+    !CACHE.config[CACHE.activeRootPath].extensions.includes(
+      doc.languageId as any
+    ) ||
     CACHE.cssVarCount[CACHE.activeRootPath] === 0 ||
     CACHE.config[CACHE.activeRootPath].mode[0] === "off"
   ) {

--- a/src/test/test-utilities.ts
+++ b/src/test/test-utilities.ts
@@ -12,12 +12,14 @@ export class TextDocumentStub {
   private _uri: string;
   lineCount: number;
   lines: string[] = [];
+  languageId: string;
 
   constructor(doc: string, uri = "foo") {
     this.document = doc;
     this.lines = doc.split("\n");
     this.lineCount = this.lines.length;
     this._uri = uri;
+    this.languageId = "css";
   }
 
   // I have used a getter here, so that I can spy it if I want


### PR DESCRIPTION
Closes #72 

- Adding support for all useful language ids enables a user to use `cssvar.extensions` setting to activate this extension for languages that are not enabled by default.
- Allow user to enable/disable this extension when not needed.